### PR TITLE
XWIKI-5887: The REST API allows to list wikis and spaces even when the wiki is protected

### DIFF
--- a/xwiki-enterprise-test/xwiki-enterprise-test-rest/src/test/it/org/xwiki/test/rest/SpacesResourceTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-rest/src/test/it/org/xwiki/test/rest/SpacesResourceTest.java
@@ -67,6 +67,12 @@ public class SpacesResourceTest extends AbstractHttpTest
             Assert.assertNotNull(link);
 
             checkLinks(space);
+
+            /*
+             * Check that in the returned spaces there are not spaces not visible to user Guest, for example the
+             * "Scheduler" space
+             */
+            Assert.assertFalse(space.getName().equals("Scheduler"));
         }
 
     }


### PR DESCRIPTION
XWIKI-5887: The REST API allows to list wikis and spaces even when the wiki is protected

Added some test code to check that the private "Scheduler" space is not returned to the guest user.
