### PR TITLE
XE-1127: ColorTheme Wizard doesn't display the logo when creating a new ...

### DIFF
--- a/xwiki-enterprise-ui/src/main/resources/ColorThemes/ColorThemeSheet.xml
+++ b/xwiki-enterprise-ui/src/main/resources/ColorThemes/ColorThemeSheet.xml
@@ -1386,7 +1386,8 @@ $xwiki.jsx.use('ColorThemes.ColorThemeSheet', {
           #end
         #end
       #end
-      #if($themeValue == '')
+      ## Get fallback values just for 'Color' properties
+      #if($themeValue == '' &amp;&amp; $themeProp.indexOf('Color') &gt;= 0)
         #set($themeValue = "${theme.get($themeProp)}")
       #end
       #if($themeValue != '' &amp;&amp; $themeProp.indexOf('Image') &gt;= 0)
@@ -1479,8 +1480,8 @@ $xwiki.jsx.use('ColorThemes.ColorThemeSheet', {
         #set($themeLogoImage = $doc.getAttachmentURL($!{obj.getProperty('logoImage').value}))
       #else
         ## If the logo is not configured, use the one in the skin or the one set by default
-        ## For this, $logourl is already set in global.vm
-        #set($themeLogoImage = "$!{logourl}")
+        ## For this, $logoname is already set in global.vm
+        #set($themeLogoImage = "$xwiki.getSkinFile($logoname)")
       #end
       &lt;img id="colorthemewizard-logo" src="$themeLogoImage" alt="$msg.get('xe.themes.colors.wizard.logo')"/&gt;
     &lt;/div&gt;

--- a/xwiki-enterprise-ui/src/main/resources/ColorThemes/DefaultColorTheme.xml
+++ b/xwiki-enterprise-ui/src/main/resources/ColorThemes/DefaultColorTheme.xml
@@ -1285,7 +1285,7 @@ RK5CYII=
 <linkColor>#0089DC</linkColor>
 </property>
 <property>
-<logoImage>logo</logoImage>
+<logoImage>logo.png</logoImage>
 </property>
 <property>
 <menuAddEntryBackgroundColor>#4D9244</menuAddEntryBackgroundColor>


### PR DESCRIPTION
...ColorTheme or visualizing a theme that has a white header background
- the logo from the current/default theme has no importance for other theme, since it can define its own or rely on the skin logo
- don't fallback on 'Image' or 'Position' values in the ColorThemeWizard, just on the 'Color' values
