### PR TITLE
XE-1147: Exclude failing Selenium 2 tests on IE8 from running

### DIFF
--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/AttachmentTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/AttachmentTest.java
@@ -24,6 +24,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.openqa.selenium.By;
+import org.xwiki.test.ui.browser.IgnoreBrowser;
 import org.xwiki.test.ui.po.AttachmentsPane;
 import org.xwiki.test.ui.po.ViewPage;
 
@@ -51,6 +52,7 @@ public class AttachmentTest extends AbstractAdminAuthenticatedTest
     }
 
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testUploadDownloadTwoAttachments()
     {
         ViewPage vp = getUtil().createPage(getTestClassName(), getTestMethodName(), null,
@@ -86,6 +88,7 @@ public class AttachmentTest extends AbstractAdminAuthenticatedTest
      * See XWIKI-5896: The image handling in the WYSIWYG-editor with GIF images is buggy.
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testAttachAndViewGifImage()
     {
         // Prepare the page to display the GIF image. We explicitly set the width to a value greater than the actual

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/BreadcrumbsTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/BreadcrumbsTest.java
@@ -22,6 +22,7 @@ package org.xwiki.test.ui;
 import junit.framework.Assert;
 
 import org.junit.Test;
+import org.xwiki.test.ui.browser.IgnoreBrowser;
 import org.xwiki.test.ui.po.ViewPage;
 
 /**
@@ -37,6 +38,7 @@ public class BreadcrumbsTest extends AbstractAdminAuthenticatedTest
     private static final String CHILD_TITLE = "Child page";
 
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testBreadcrumbs()
     {
         // Delete the page to reset the rights on it (since the test below modifies them).

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/CommentAsGuestTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/CommentAsGuestTest.java
@@ -24,6 +24,7 @@ import junit.framework.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.xwiki.test.po.administration.GlobalRightsAdministrationSectionPage;
+import org.xwiki.test.ui.browser.IgnoreBrowser;
 import org.xwiki.test.ui.po.CommentsTab;
 import org.xwiki.test.ui.po.ViewPage;
 import org.xwiki.test.ui.po.EditRightsPane.Right;
@@ -80,6 +81,7 @@ public class CommentAsGuestTest extends AbstractAdminAuthenticatedTest
     }
 
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testPostCommentAsGuest()
     {
         CommentsTab commentsTab = this.vp.openCommentsDocExtraPane();
@@ -90,6 +92,7 @@ public class CommentAsGuestTest extends AbstractAdminAuthenticatedTest
     }
 
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testPostCommentAsGuestNoJs()
     {
         getUtil().gotoPage(SPACE_NAME, DOC_NAME, "view", "xpage=xpart&vm=commentsinline.vm");
@@ -105,6 +108,7 @@ public class CommentAsGuestTest extends AbstractAdminAuthenticatedTest
     }
 
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testReplyCommentAsAnonymous()
     {
         CommentsTab commentsTab = this.vp.openCommentsDocExtraPane();
@@ -118,6 +122,7 @@ public class CommentAsGuestTest extends AbstractAdminAuthenticatedTest
     }
 
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testCannotEditCommentAsAnonymous()
     {
         CommentsTab commentsTab = this.vp.openCommentsDocExtraPane();

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/CopyPageTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/CopyPageTest.java
@@ -22,6 +22,7 @@ package org.xwiki.test.ui;
 import junit.framework.Assert;
 
 import org.junit.Test;
+import org.xwiki.test.ui.browser.IgnoreBrowser;
 import org.xwiki.test.ui.po.CopyConfirmationPage;
 import org.xwiki.test.ui.po.CopyPage;
 import org.xwiki.test.ui.po.ViewPage;
@@ -39,6 +40,7 @@ public class CopyPageTest extends AbstractAdminAuthenticatedTest
     private static final String COPY_SUCCESSFUL = "successfully copied to";
 
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testCopyPage()
     {
         // Delete page that may already exist

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/CreatePageTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/CreatePageTest.java
@@ -28,6 +28,7 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.xwiki.test.po.administration.TemplateProviderInlinePage;
 import org.xwiki.test.po.administration.TemplatesAdministrationSectionPage;
+import org.xwiki.test.ui.browser.IgnoreBrowser;
 import org.xwiki.test.ui.po.CreatePagePage;
 import org.xwiki.test.ui.po.CreateSpacePage;
 import org.xwiki.test.ui.po.DocumentDoesNotExistPage;
@@ -83,6 +84,7 @@ public class CreatePageTest extends AbstractAdminAuthenticatedTest
      * Tests if a new page can be created from a template.
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testCreatePageFromTemplate()
     {
         // Setup the correct environment for the test
@@ -205,6 +207,7 @@ public class CreatePageTest extends AbstractAdminAuthenticatedTest
      * Tests that creating a space works fine.
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testCreateSpace()
     {
         // create a random space
@@ -230,6 +233,7 @@ public class CreatePageTest extends AbstractAdminAuthenticatedTest
      * Tests that creating a page or a space that already exists displays an error.
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testCreateExistingPage()
     {
         String space = this.getClass().getSimpleName();
@@ -293,6 +297,7 @@ public class CreatePageTest extends AbstractAdminAuthenticatedTest
      * Tests what happens when creating a page when no template is available in the specific space.
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testCreatePageWhenNoTemplateAvailable()
     {
         // prepare the test environment, create a test space and exclude all templates for this space
@@ -391,6 +396,7 @@ public class CreatePageTest extends AbstractAdminAuthenticatedTest
      * Tests the creation of a page from a save and edit template, tests that the page is indeed saved.
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testCreatePageWithSaveAndEditTemplate()
     {
         String space = this.getClass().getSimpleName();

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/EditClassTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/EditClassTest.java
@@ -23,6 +23,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.openqa.selenium.By;
+import org.xwiki.test.ui.browser.IgnoreBrowser;
 import org.xwiki.test.ui.po.FormElement;
 import org.xwiki.test.ui.po.ViewPage;
 import org.xwiki.test.ui.po.editor.ClassEditPage;
@@ -46,6 +47,7 @@ public class EditClassTest extends AbstractAdminAuthenticatedTest
     }
 
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testAddProperty()
     {
         // We verify that we can click on Edit Class from View Page (we need to test this at
@@ -70,6 +72,7 @@ public class EditClassTest extends AbstractAdminAuthenticatedTest
     }
 
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testDeleteProperty()
     {
         // Create a class with two string properties

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/EditObjectsTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/EditObjectsTest.java
@@ -25,6 +25,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.openqa.selenium.By;
+import org.xwiki.test.ui.browser.IgnoreBrowser;
 import org.xwiki.test.ui.po.FormElement;
 import org.xwiki.test.ui.po.ViewPage;
 import org.xwiki.test.ui.po.editor.ClassEditPage;
@@ -73,6 +74,7 @@ public class EditObjectsTest extends AbstractAdminAuthenticatedTest
      * Tests that XWIKI-1621 remains fixed.
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testChangeMultiselectProperty()
     {
         // Create a class with a database list property set to return all documents
@@ -111,6 +113,7 @@ public class EditObjectsTest extends AbstractAdminAuthenticatedTest
      * Tests that XWIKI-2214 remains fixed.
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testChangeNumberType()
     {
         // Create class page
@@ -167,6 +170,7 @@ public class EditObjectsTest extends AbstractAdminAuthenticatedTest
      * XWIKI-299 test
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testChangeListMultipleSelect()
     {
         // Create class page
@@ -216,6 +220,7 @@ public class EditObjectsTest extends AbstractAdminAuthenticatedTest
      * XWIKI-1621: Changing parameters of list properties fails
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testChangeListTypeRelationalStorage()
     {
         // Create class page
@@ -272,6 +277,7 @@ public class EditObjectsTest extends AbstractAdminAuthenticatedTest
     }
 
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testObjectAddAndRemove()
     {
         ObjectEditPage oep = ObjectEditPage.gotoPage("Test", "EditObjectsTestObject");

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/EditWYSIWYGTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/EditWYSIWYGTest.java
@@ -27,6 +27,7 @@ import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.xwiki.test.po.administration.ProfileUserProfilePage;
+import org.xwiki.test.ui.browser.IgnoreBrowser;
 import org.xwiki.test.ui.po.editor.ProfileEditPage;
 import org.xwiki.test.ui.po.editor.WYSIWYGEditPage;
 import org.xwiki.test.ui.po.editor.wysiwyg.EditorElement;
@@ -64,6 +65,7 @@ public class EditWYSIWYGTest extends AbstractAdminAuthenticatedTest
      *      and previewing it without saving the page first makes the XWiki page corrupt.
      **/
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testUploadImageAfterPreview()
     {
         this.editPage.clickPreview().clickBackToEdit();
@@ -78,6 +80,7 @@ public class EditWYSIWYGTest extends AbstractAdminAuthenticatedTest
      * @see XWIKI:7028: Strange behaviour when pressing back and forward on a page that has 2 WYSIWYG editors displayed.
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testBackForwardCache()
     {
         ProfileEditPage profileEditPage = ProfileUserProfilePage.gotoPage("Admin").editProfile();
@@ -95,6 +98,7 @@ public class EditWYSIWYGTest extends AbstractAdminAuthenticatedTest
      * Test that the content of the rich text area is preserved when the user refreshes the page.
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testPreserveUnsavedRichContentAgainstRefresh()
     {
         // Type text and refresh the page.
@@ -115,6 +119,7 @@ public class EditWYSIWYGTest extends AbstractAdminAuthenticatedTest
      * Test that the content of the source text area is preserved when the user refreshes the page.
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testPreserveUnsavedSourceAgainstRefresh()
     {
         EditorElement editor = this.editPage.getContentEditor();
@@ -137,6 +142,7 @@ public class EditWYSIWYGTest extends AbstractAdminAuthenticatedTest
      * Tests that the currently active editor (WYSIWYG or Source) is preserved when the user refreshes the page.
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testPreserveSelectedEditorAgainstRefresh()
     {
         // The WYSIWYG editor should be initially active.
@@ -170,6 +176,7 @@ public class EditWYSIWYGTest extends AbstractAdminAuthenticatedTest
      * Test if an undo step reverts only one paste operation from a sequence, and not all of them.
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testUndoRepeatedPaste()
     {
         EditorElement editor = this.editPage.getContentEditor();
@@ -216,6 +223,7 @@ public class EditWYSIWYGTest extends AbstractAdminAuthenticatedTest
      * @see http://jira.xwiki.org/jira/browse/XWIKI-3304
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testDotAtEndDoesNotDelete()
     {
         EditorElement editor = this.editPage.getContentEditor();

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/EditWikiTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/EditWikiTest.java
@@ -24,6 +24,7 @@ import junit.framework.Assert;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.Before;
 import org.junit.Test;
+import org.xwiki.test.ui.browser.IgnoreBrowser;
 import org.xwiki.test.ui.po.ViewPage;
 import org.xwiki.test.ui.po.editor.EditPage.Editor;
 import org.xwiki.test.ui.po.editor.WYSIWYGEditPage;
@@ -75,6 +76,7 @@ public class EditWikiTest extends AbstractAdminAuthenticatedTest
      * displayed if the page syntax is xwiki/2.0.
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testSwitchToWysiwygWithAdvancedContent()
     {
         // Place some HTML in the page content.
@@ -91,6 +93,7 @@ public class EditWikiTest extends AbstractAdminAuthenticatedTest
      * @see XWIKI-6934: Preview action doesn't displays the page's title
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testPreviewDisplaysPageTitle()
     {
         String title = RandomStringUtils.randomAlphanumeric(3);

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/InternationalizationTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/InternationalizationTest.java
@@ -22,6 +22,7 @@ package org.xwiki.test.ui;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.xwiki.test.ui.browser.IgnoreBrowser;
 import org.xwiki.test.ui.po.CreatePagePage;
 import org.xwiki.test.ui.po.CreateSpacePage;
 import org.xwiki.test.ui.po.ViewPage;
@@ -54,6 +55,7 @@ public class InternationalizationTest extends AbstractAdminAuthenticatedTest
      * Checks that non-ASCII characters are allowed in the space name.
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testCreateNonAsciiSpace()
     {
         CreateSpacePage createSpacePage = this.homePage.createSpace();
@@ -74,6 +76,7 @@ public class InternationalizationTest extends AbstractAdminAuthenticatedTest
      * Checks that non-ASCII characters are allowed in the page name.
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testCreateNonAsciiPage()
     {
         CreatePagePage createPagePage = this.homePage.createPage();

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/KeyboardShortcutsTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/KeyboardShortcutsTest.java
@@ -23,6 +23,7 @@ import junit.framework.Assert;
 
 import org.junit.Test;
 import org.openqa.selenium.Keys;
+import org.xwiki.test.ui.browser.IgnoreBrowser;
 import org.xwiki.test.ui.po.ViewPage;
 
 /**
@@ -36,6 +37,7 @@ public class KeyboardShortcutsTest extends AbstractAdminAuthenticatedTest
     private TestUtils util = new TestUtils();
 
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testKeyboardShortcuts()
     {
         ViewPage vp = util.gotoPage("Sandbox", "WebHome");

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/LanguageTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/LanguageTest.java
@@ -27,6 +27,7 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.xwiki.test.po.administration.AdministrationPage;
 import org.xwiki.test.po.administration.LocalizationAdministrationSectionPage;
+import org.xwiki.test.ui.browser.IgnoreBrowser;
 import org.xwiki.test.ui.po.ViewPage;
 import org.xwiki.test.ui.po.editor.WikiEditPage;
 
@@ -60,6 +61,7 @@ public class LanguageTest extends AbstractAdminAuthenticatedTest
     }
 
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testChangeLanguageInMonolingualModeUsingTheAdministrationPreference()
     {
         WikiEditPage edit = WikiEditPage.gotoPage("Test", "LanguageTest");
@@ -86,6 +88,7 @@ public class LanguageTest extends AbstractAdminAuthenticatedTest
     }
 
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testPassingLanguageInRequestHasNoEffectInMonoligualMode()
     {
         getUtil().gotoPage("Main", "WebHome", "view", "language=fr");
@@ -93,6 +96,7 @@ public class LanguageTest extends AbstractAdminAuthenticatedTest
     }
 
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testChangeLanguageInMultilingualModeUsingTheLanguageRequestParameter()
     {
         setLanguageSettings(true, "en");
@@ -102,6 +106,7 @@ public class LanguageTest extends AbstractAdminAuthenticatedTest
     }
 
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testHeaderCorrectLanguage()
     {
         setLanguageSettings(true, "en");

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/LoginTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/LoginTest.java
@@ -23,6 +23,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.xwiki.test.po.administration.GlobalRightsAdministrationSectionPage;
+import org.xwiki.test.ui.browser.IgnoreBrowser;
 import org.xwiki.test.ui.po.LoginPage;
 import org.xwiki.test.ui.po.ResubmissionPage;
 import org.xwiki.test.ui.po.ViewPage;
@@ -52,6 +53,7 @@ public class LoginTest extends AbstractTest
     }
 
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testLoginLogoutAsAdmin()
     {
         LoginPage loginPage = this.vp.login();
@@ -71,6 +73,7 @@ public class LoginTest extends AbstractTest
     }
 
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testLoginWithInvalidCredentials()
     {
         LoginPage loginPage = this.vp.login();
@@ -79,6 +82,7 @@ public class LoginTest extends AbstractTest
     }
 
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testLoginWithInvalidUsername()
     {
         LoginPage loginPage = this.vp.login();
@@ -123,6 +127,7 @@ public class LoginTest extends AbstractTest
     }
 
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testRedirectPreservesPOSTParameters()
     {
         String test = "Test string " + System.currentTimeMillis();
@@ -154,6 +159,7 @@ public class LoginTest extends AbstractTest
     }
 
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testCorrectUrlIsAccessedAfterLogin()
     {
         // We will choose the Scheduler.WebHome page to make our testing
@@ -168,6 +174,7 @@ public class LoginTest extends AbstractTest
     }
 
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testDataIsPreservedAfterLogin()
     {
         getUtil().gotoPage("Test", "TestData", "save", "content=this+should+not+be+saved");

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/RegisterTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/RegisterTest.java
@@ -28,6 +28,7 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.WebDriverException;
 import org.xwiki.test.po.administration.AdministrationSectionPage;
+import org.xwiki.test.ui.browser.IgnoreBrowser;
 import org.xwiki.test.ui.po.AbstractRegistrationPage;
 import org.xwiki.test.ui.po.RegistrationPage;
 
@@ -92,6 +93,7 @@ public class RegisterTest extends AbstractTest
     }
 
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testRegisterJohnSmith()
     {
         Assert.assertTrue(validateAndRegister());
@@ -99,6 +101,7 @@ public class RegisterTest extends AbstractTest
     }
 
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testRegisterExistingUser()
     {
         registrationPage.fillRegisterForm(null, null, "Admin", null, null, null);
@@ -108,6 +111,7 @@ public class RegisterTest extends AbstractTest
     }
 
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testRegisterPasswordTooShort()
     {
         this.registrationPage.fillRegisterForm(null, null, null, "short", "short", null);
@@ -116,6 +120,7 @@ public class RegisterTest extends AbstractTest
     }
 
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testRegisterDifferentPasswords()
     {
         this.registrationPage.fillRegisterForm(null, null, null, null, "DifferentPassword", null);
@@ -124,6 +129,7 @@ public class RegisterTest extends AbstractTest
     }
 
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testRegisterEmptyPassword()
     {
         this.registrationPage.fillRegisterForm(null, null, null, "", "", null);
@@ -132,6 +138,7 @@ public class RegisterTest extends AbstractTest
     }
 
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testRegisterEmptyUserName()
     {
         // A piece of javascript fills in the username with the first and last names so we will empty them.
@@ -141,6 +148,7 @@ public class RegisterTest extends AbstractTest
     }
 
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testRegisterInvalidEmail()
     {
         this.registrationPage.fillRegisterForm(null, null, null, null, null, "not an email address");

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/SectionTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/SectionTest.java
@@ -20,6 +20,7 @@
 package org.xwiki.test.ui;
 
 import org.junit.Test;
+import org.xwiki.test.ui.browser.IgnoreBrowser;
 import org.xwiki.test.ui.po.ViewPage;
 import org.xwiki.test.ui.po.editor.WYSIWYGEditPage;
 import org.xwiki.test.ui.po.editor.WikiEditPage;
@@ -68,6 +69,7 @@ public class SectionTest extends AbstractAdminAuthenticatedTest
      * See XWIKI-174: Sectional editing.
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testSectionEditInEditorWhenSyntax10()
     {
         ViewPage vp = createTestPages("xwiki/1.0");
@@ -101,6 +103,7 @@ public class SectionTest extends AbstractAdminAuthenticatedTest
      * See XWIKI-2881: Implement Section editing.
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testSectionEditInWikiEditorWhenSyntax2x()
     {
         testSectionEditInWikiEditorWhenSyntax2x("xwiki/2.0");
@@ -141,6 +144,7 @@ public class SectionTest extends AbstractAdminAuthenticatedTest
      * See XWIKI-4033: When saving after section edit entire page is overwritten.
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testSectionSaveDoesNotOverwriteTheWholeContentWhenSyntax10()
     {
         ViewPage vp = createTestPages("xwiki/1.0");
@@ -155,6 +159,7 @@ public class SectionTest extends AbstractAdminAuthenticatedTest
      * See XWIKI-4033: When saving after section edit entire page is overwritten.
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testSectionSaveDoesNotOverwriteTheWholeContentWhenSyntax20()
     {
         ViewPage vp = createTestPages("xwiki/2.0");

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/TemplateTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/TemplateTest.java
@@ -23,6 +23,7 @@ import junit.framework.Assert;
 
 import org.junit.Test;
 import org.openqa.selenium.By;
+import org.xwiki.test.ui.browser.IgnoreBrowser;
 import org.xwiki.test.ui.po.editor.WikiEditPage;
 
 /**
@@ -40,6 +41,7 @@ public class TemplateTest extends AbstractAdminAuthenticatedTest
      * Test that velocity is rendered
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testHelloVelocity()
     {
         String hello = "Hello Velocity Test Test Test";
@@ -51,6 +53,7 @@ public class TemplateTest extends AbstractAdminAuthenticatedTest
      * Test that an included existing template is displayed correctly
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testCorrectTemplate()
     {
         saveVelocity(includeTemplate("code.vm"), true);
@@ -62,6 +65,7 @@ public class TemplateTest extends AbstractAdminAuthenticatedTest
      * See XWIKI-2580
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testWrongTemplate()
     {
         saveVelocity(includeTemplate("../../"));

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/VersionTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/VersionTest.java
@@ -22,6 +22,7 @@ package org.xwiki.test.ui;
 import junit.framework.Assert;
 
 import org.junit.Test;
+import org.xwiki.test.ui.browser.IgnoreBrowser;
 import org.xwiki.test.ui.po.HistoryTab;
 import org.xwiki.test.ui.po.ViewPage;
 import org.xwiki.test.ui.po.editor.WikiEditPage;
@@ -45,6 +46,7 @@ public class VersionTest extends AbstractAdminAuthenticatedTest
     private static final String CONTENT2 = "Second version of Content";
 
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testRollbackToFirstVersion() throws Exception
     {
         getUtil().deletePage(SPACE_NAME, PAGE_NAME);

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/administration/ImportTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/administration/ImportTest.java
@@ -29,6 +29,7 @@ import org.openqa.selenium.WebElement;
 import org.xwiki.test.ui.AbstractAdminAuthenticatedTest;
 import org.xwiki.test.po.administration.AdministrationPage;
 import org.xwiki.test.po.administration.ImportAdministrationSectionPage;
+import org.xwiki.test.ui.browser.IgnoreBrowser;
 import org.xwiki.test.ui.po.HistoryTab;
 import org.xwiki.test.ui.po.ViewPage;
 
@@ -86,6 +87,7 @@ public class ImportTest extends AbstractAdminAuthenticatedTest
     }
 
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testImportWithHistory()
     {
         URL fileUrl = this.getClass().getResource("/administration/" + PACKAGE_WITH_HISTORY);
@@ -109,6 +111,7 @@ public class ImportTest extends AbstractAdminAuthenticatedTest
     }
 
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testImportWithNewHistoryVersion()
     {
         URL fileUrl = this.getClass().getResource("/administration/" + PACKAGE_WITHOUT_HISTORY);
@@ -130,6 +133,7 @@ public class ImportTest extends AbstractAdminAuthenticatedTest
     }
 
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testImportAsBackup()
     {
         URL fileUrl = this.getClass().getResource("/administration/" + BACKUP_PACKAGE);
@@ -153,6 +157,7 @@ public class ImportTest extends AbstractAdminAuthenticatedTest
     }
 
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testImportWhenImportAsBackupIsNotSelected()
     {
         URL fileUrl = this.getClass().getResource("/administration/" + BACKUP_PACKAGE);

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/administration/UserProfileTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/administration/UserProfileTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 import org.xwiki.test.ui.AbstractTest;
 import org.xwiki.test.po.administration.PreferencesUserProfilePage;
 import org.xwiki.test.po.administration.ProfileUserProfilePage;
+import org.xwiki.test.ui.browser.IgnoreBrowser;
 import org.xwiki.test.ui.po.editor.ChangeAvatarPage;
 import org.xwiki.test.ui.po.editor.ChangePasswordPage;
 import org.xwiki.test.ui.po.editor.PreferencesEditPage;
@@ -93,6 +94,7 @@ public class UserProfileTest extends AbstractTest
 
     /** Functionality check: changing profile information. */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testEditProfile()
     {
         ProfileEditPage profileEditPage = this.customProfilePage.editProfile();
@@ -123,6 +125,7 @@ public class UserProfileTest extends AbstractTest
 
     /** Functionality check: changing the profile picture. */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testChangeAvatarImage()
     {
         ChangeAvatarPage changeAvatarImage = this.customProfilePage.changeAvatarImage();
@@ -133,6 +136,7 @@ public class UserProfileTest extends AbstractTest
 
     /** Functionality check: changing the password. */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testChangePassword()
     {
         // Change the password
@@ -155,6 +159,7 @@ public class UserProfileTest extends AbstractTest
 
     /** Functionality check: changing the user type. */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testChangeUserProfile()
     {
         PreferencesUserProfilePage preferencesPage = this.customProfilePage.switchToPreferences();
@@ -175,6 +180,7 @@ public class UserProfileTest extends AbstractTest
 
     /** Functionality check: changing the default editor. */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testChangeDefaultEditor()
     {
         PreferencesUserProfilePage preferencesPage = this.customProfilePage.switchToPreferences();
@@ -225,6 +231,7 @@ public class UserProfileTest extends AbstractTest
     }
 
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testChangePasswordWithTwoDifferentPasswords()
     {
         PreferencesUserProfilePage preferencesPage = this.customProfilePage.switchToPreferences();
@@ -247,6 +254,7 @@ public class UserProfileTest extends AbstractTest
     }
 
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testChangePasswordWithoutEnteringPasswords()
     {
         PreferencesUserProfilePage preferencesPage = this.customProfilePage.switchToPreferences();
@@ -268,6 +276,7 @@ public class UserProfileTest extends AbstractTest
     }
 
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testChangePasswordOfAnotherUserWithTwoDifferentPasswords()
     {
         // Login as Admin and change the password of another user

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/annotations/AnnotationsTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/annotations/AnnotationsTest.java
@@ -24,6 +24,7 @@ import junit.framework.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.xwiki.test.ui.AbstractAdminAuthenticatedTest;
+import org.xwiki.test.ui.browser.IgnoreBrowser;
 import org.xwiki.test.po.annotations.AnnotatableViewPage;
 
 /**
@@ -67,6 +68,7 @@ public class AnnotationsTest extends AbstractAdminAuthenticatedTest
     }
 
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void AddAndDeleteAnnotations()
     {
         annotatableViewPage.addAnnotation(ANNOTATED_TEXT_1, ANNOTATION_TEXT_1);

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/appwithinminutes/ApplicationNameTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/appwithinminutes/ApplicationNameTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.openqa.selenium.Keys;
 import org.xwiki.test.ui.AbstractAdminAuthenticatedTest;
 import org.xwiki.test.po.appwithinminutes.ApplicationCreatePage;
+import org.xwiki.test.ui.browser.IgnoreBrowser;
 import org.xwiki.test.ui.po.ViewPage;
 
 /**
@@ -55,6 +56,7 @@ public class ApplicationNameTest extends AbstractAdminAuthenticatedTest
      * Try to create an application with an empty name using the next step button.
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testEmptyAppNameWithNextStepButton()
     {
         ApplicationCreatePage appCreatePage = ApplicationCreatePage.gotoPage();
@@ -89,6 +91,7 @@ public class ApplicationNameTest extends AbstractAdminAuthenticatedTest
      * Try to create an application with an empty name using the Enter key.
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testEmptyAppNameWithEnter()
     {
         ApplicationCreatePage appCreatePage = ApplicationCreatePage.gotoPage();
@@ -124,6 +127,7 @@ public class ApplicationNameTest extends AbstractAdminAuthenticatedTest
      * Try to create an application with a name that can't be used to compute a valid class name.
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testInvalidAppName()
     {
         ApplicationCreatePage appCreatePage = ApplicationCreatePage.gotoPage();
@@ -159,6 +163,7 @@ public class ApplicationNameTest extends AbstractAdminAuthenticatedTest
      * Try to input the name of an existing application.
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testExistingAppName()
     {
         ApplicationCreatePage appCreatePage = ApplicationCreatePage.gotoPage();

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/appwithinminutes/AppsLiveTableTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/appwithinminutes/AppsLiveTableTest.java
@@ -32,6 +32,7 @@ import org.xwiki.test.po.appwithinminutes.ApplicationHomePage;
 import org.xwiki.test.po.appwithinminutes.ApplicationsLiveTableElement;
 import org.xwiki.test.po.appwithinminutes.ClassFieldEditPane;
 import org.xwiki.test.ui.AbstractTest;
+import org.xwiki.test.ui.browser.IgnoreBrowser;
 
 /**
  * Tests the live table that lists the existing applications on the AppWithinMinutes home page.
@@ -59,6 +60,7 @@ public class AppsLiveTableTest extends AbstractTest
      * Creates an application and deletes it using the Actions column from the applications live table.
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testDeleteApplication()
     {
         // Create the application.
@@ -97,6 +99,7 @@ public class AppsLiveTableTest extends AbstractTest
      * Creates an application and edits it using the Actions column from the applications live table.
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testEditApplication()
     {
         // Create the application.
@@ -127,6 +130,7 @@ public class AppsLiveTableTest extends AbstractTest
      * Tests that the actions are displayed only when the current user has the right to perform them.
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testActionRights()
     {
         // Create the application.

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/appwithinminutes/ClassEditorTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/appwithinminutes/ClassEditorTest.java
@@ -29,6 +29,7 @@ import org.xwiki.test.po.appwithinminutes.ClassFieldEditPane;
 import org.xwiki.test.po.appwithinminutes.EntryEditPage;
 import org.xwiki.test.po.appwithinminutes.LongTextClassFieldEditPane;
 import org.xwiki.test.po.xe.ClassSheetPage;
+import org.xwiki.test.ui.browser.IgnoreBrowser;
 import org.xwiki.test.ui.po.ViewPage;
 import org.xwiki.test.ui.po.editor.ObjectEditPage;
 
@@ -49,6 +50,7 @@ public class ClassEditorTest extends AbstractClassEditorTest
      * Tests that the hint is displayed only when the canvas is empty.
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testEmptyCanvasHint()
     {
         Assert.assertTrue(editor.getContent().contains(EMPTY_CANVAS_HINT));
@@ -62,6 +64,7 @@ public class ClassEditorTest extends AbstractClassEditorTest
      * Tests that the field display is updated when the configuration panel is closed.
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testApplyConfigurationChanges()
     {
         LongTextClassFieldEditPane longTextField =
@@ -77,6 +80,7 @@ public class ClassEditorTest extends AbstractClassEditorTest
      * Tests that class fields can be deleted and that documents having objects of that class are updated.
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testDeleteField()
     {
         // Add two fields.
@@ -108,6 +112,7 @@ public class ClassEditorTest extends AbstractClassEditorTest
      * Tests that class fields can be reordered.
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testReorderFields()
     {
         // Add two class fields.
@@ -146,6 +151,7 @@ public class ClassEditorTest extends AbstractClassEditorTest
      * Tests that class fields can be renamed.
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testRenameField()
     {
         // Add a class field.
@@ -178,6 +184,7 @@ public class ClassEditorTest extends AbstractClassEditorTest
      * Tests that invalid field names are not allowed.
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testInvalidFieldName()
     {
         String invalidFieldNameErrorMessage = "Property names must follow these naming rules:";
@@ -211,6 +218,7 @@ public class ClassEditorTest extends AbstractClassEditorTest
      * Tests that two class fields can't have the same name.
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testDuplicateFieldName()
     {
         ClassFieldEditPane field = editor.addField("Short Text");
@@ -231,6 +239,7 @@ public class ClassEditorTest extends AbstractClassEditorTest
      * Tests that swapping field names is not allowed.
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testSwapFieldNames()
     {
         ClassFieldEditPane field = editor.addField("Short Text");
@@ -260,6 +269,7 @@ public class ClassEditorTest extends AbstractClassEditorTest
      * Tests the options to update the class sheet and the class template.
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testUpdateSheetAndTemplate()
     {
         // The options panel is not displayed if the class template and sheet don't exists.
@@ -299,6 +309,7 @@ public class ClassEditorTest extends AbstractClassEditorTest
      * Tests the Save & Continue button.
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testSaveAndContinue()
     {
         editor.addField("Date");
@@ -329,6 +340,7 @@ public class ClassEditorTest extends AbstractClassEditorTest
      * Tests that fields names are auto-generated properly.
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testFieldNameAutoGeneration()
     {
         // Add a class field and set its name to an auto-generated field name for a different type.
@@ -355,6 +367,7 @@ public class ClassEditorTest extends AbstractClassEditorTest
      * Test that Save And Continue supports field renames.
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testRenameWithSaveAndContinue()
     {
         // Add a class field.

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/appwithinminutes/DateClassFieldTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/appwithinminutes/DateClassFieldTest.java
@@ -27,6 +27,7 @@ import junit.framework.Assert;
 import org.junit.Test;
 import org.xwiki.test.po.appwithinminutes.DateClassFieldEditPane;
 import org.xwiki.test.po.appwithinminutes.DatePicker;
+import org.xwiki.test.ui.browser.IgnoreBrowser;
 
 /**
  * Special class editor tests that address only the Date class field type.
@@ -40,6 +41,7 @@ public class DateClassFieldTest extends AbstractClassEditorTest
      * Tests that the user can select a date using the date picker.
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testDatePicker()
     {
         // First select a date using the picker and assert the value of the date input.
@@ -74,6 +76,7 @@ public class DateClassFieldTest extends AbstractClassEditorTest
      * serialized using the specified date format.
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testDateFormat()
     {
         // Add a date field and change the date format.

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/appwithinminutes/LiveTableEditorTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/appwithinminutes/LiveTableEditorTest.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 import org.xwiki.test.po.appwithinminutes.ApplicationHomeEditPage;
 import org.xwiki.test.po.appwithinminutes.ApplicationHomePage;
 import org.xwiki.test.ui.AbstractAdminAuthenticatedTest;
+import org.xwiki.test.ui.browser.IgnoreBrowser;
 import org.xwiki.test.ui.po.LiveTableElement;
 
 /**
@@ -67,6 +68,7 @@ public class LiveTableEditorTest extends AbstractAdminAuthenticatedTest
      * Adds, removes and reorders live table columns.
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testManageColumns()
     {
         editPage.addLiveTableColumn("First Name");
@@ -85,6 +87,7 @@ public class LiveTableEditorTest extends AbstractAdminAuthenticatedTest
      * Tests that Save & Continue works fine.
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testSaveAndContinue()
     {
         editPage.setDescription("wait for WYSIWYG to load");

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/appwithinminutes/StaticListClassFieldTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/appwithinminutes/StaticListClassFieldTest.java
@@ -26,6 +26,7 @@ import junit.framework.Assert;
 import org.junit.Test;
 import org.xwiki.test.po.appwithinminutes.StaticListClassFieldEditPane;
 import org.xwiki.test.po.appwithinminutes.StaticListItemsEditor;
+import org.xwiki.test.ui.browser.IgnoreBrowser;
 
 /**
  * Special class editor tests that address only the Static List class field type.
@@ -40,6 +41,7 @@ public class StaticListClassFieldTest extends AbstractClassEditorTest
      * be preserved.
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testDisplayType()
     {
         // Add a new static list field.
@@ -82,6 +84,7 @@ public class StaticListClassFieldTest extends AbstractClassEditorTest
      * Tests that multiple select state is synchronized with the rest of the meta properties.
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testMultipleSelect()
     {
         // Add a new static list field.
@@ -112,6 +115,7 @@ public class StaticListClassFieldTest extends AbstractClassEditorTest
      * Tests the ability to add, edit and remove list items.
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testItemsEditor()
     {
         // Add a new static list field.

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/appwithinminutes/WizardTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/appwithinminutes/WizardTest.java
@@ -34,6 +34,7 @@ import org.xwiki.test.po.appwithinminutes.ClassFieldEditPane;
 import org.xwiki.test.po.appwithinminutes.EntryEditPage;
 import org.xwiki.test.po.appwithinminutes.EntryNamePane;
 import org.xwiki.test.ui.AbstractTest;
+import org.xwiki.test.ui.browser.IgnoreBrowser;
 import org.xwiki.test.ui.po.LiveTableElement;
 
 /**
@@ -66,6 +67,7 @@ public class WizardTest extends AbstractTest
      * Tests the application creation process from start to end.
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testCreateApplication()
     {
         // Step 1
@@ -205,6 +207,7 @@ public class WizardTest extends AbstractTest
      * @see XWIKI-7380: Cannot go back from step 2 to step 1
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testGoBackToFirstStep()
     {
         // Step 1

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/blog/BlogCategoriesTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/blog/BlogCategoriesTest.java
@@ -24,6 +24,7 @@ import junit.framework.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.xwiki.test.ui.AbstractAdminAuthenticatedTest;
+import org.xwiki.test.ui.browser.IgnoreBrowser;
 import org.xwiki.test.po.blog.ManageCategoriesPage;
 
 /**
@@ -53,6 +54,7 @@ public class BlogCategoriesTest extends AbstractAdminAuthenticatedTest
     }
 
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testCategoryAddRenameRemove()
     {
         categoryAdd(CATEGORY);

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/blog/BlogPostTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/blog/BlogPostTest.java
@@ -26,6 +26,7 @@ import junit.framework.Assert;
 
 import org.junit.Test;
 import org.xwiki.test.ui.AbstractAdminAuthenticatedTest;
+import org.xwiki.test.ui.browser.IgnoreBrowser;
 import org.xwiki.test.po.blog.BlogHomePage;
 import org.xwiki.test.po.blog.BlogPostInlinePage;
 import org.xwiki.test.po.blog.BlogPostViewPage;
@@ -43,6 +44,7 @@ public class BlogPostTest extends AbstractAdminAuthenticatedTest
      * Tests how a blog post is created and then edited.
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testCreateAndEditBlogPost()
     {
         getUtil().deletePage("Blog", getTestMethodName());

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/invitation/InvitationTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/invitation/InvitationTest.java
@@ -41,6 +41,7 @@ import org.xwiki.test.po.invitation.InvitationActionConfirmationElement;
 import org.xwiki.test.po.invitation.InvitationGuestActionsPage;
 import org.xwiki.test.po.invitation.InvitationMessageDisplayElement;
 import org.xwiki.test.po.invitation.InvitationSenderPage;
+import org.xwiki.test.ui.browser.IgnoreBrowser;
 import org.xwiki.test.ui.po.RegistrationPage;
 import org.xwiki.test.ui.po.TableElement;
 import org.xwiki.test.ui.po.editor.ObjectEditPage;
@@ -130,6 +131,7 @@ public class InvitationTest extends AbstractTest
     }
 
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testSendMailToTwoAddresses() throws Exception
     {
         try {
@@ -185,6 +187,7 @@ public class InvitationTest extends AbstractTest
     }
 
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testPreviewMessage()
     {
         InvitationMessageDisplayElement preview = getSenderPage().preview();
@@ -194,6 +197,7 @@ public class InvitationTest extends AbstractTest
     }
 
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testNonAdminCanSend() throws Exception
     {
         TestUtils.Session s = getUtil().getSession();
@@ -231,6 +235,7 @@ public class InvitationTest extends AbstractTest
      * will work and message will say mail was sent.
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testUnpermittedUserCannotSendToMultipleAddresses() throws Exception
     {
         TestUtils.Session admin = getUtil().getSession();
@@ -282,6 +287,7 @@ public class InvitationTest extends AbstractTest
      * 4. After an admin marks the message as not spam, the sender can again send mail.
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testSpamReporting() throws Exception
     {
         TestUtils.Session admin = getUtil().getSession();
@@ -377,6 +383,7 @@ public class InvitationTest extends AbstractTest
      * 5. A guest cannot accept a message which has already been declined.
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testDeclineInvitation() throws Exception
     {
         TestUtils.Session admin = getUtil().getSession();
@@ -447,6 +454,7 @@ public class InvitationTest extends AbstractTest
      * 4. An invitation once accepted can still be reported as spam.
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testAcceptInvitation() throws Exception
     {
         TestUtils.Session admin = getUtil().getSession();
@@ -503,6 +511,7 @@ public class InvitationTest extends AbstractTest
      * 2. Upon recieving an email invitation the guest can register even without register premission.
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testAcceptInvitationToClosedWiki() throws Exception
     {
         TestUtils.Session admin = getUtil().getSession();
@@ -574,6 +583,7 @@ public class InvitationTest extends AbstractTest
      * 4. A canceled invitation can still be reported as spam.
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testCancelInvitation() throws Exception
     {
         TestUtils.Session admin = getUtil().getSession();

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/panels/NewPagePanelTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/panels/NewPagePanelTest.java
@@ -23,6 +23,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.xwiki.test.ui.AbstractAdminAuthenticatedTest;
 import org.xwiki.test.po.panels.NewPagePanel;
+import org.xwiki.test.ui.browser.IgnoreBrowser;
 import org.xwiki.test.ui.po.editor.WYSIWYGEditPage;
 
 /**
@@ -37,6 +38,7 @@ public class NewPagePanelTest extends AbstractAdminAuthenticatedTest
      * Tests if a new page can be created using the create page panel.
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testCreatePageFromPanel()
     {
         NewPagePanel newPagePanel = NewPagePanel.gotoPage();

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/scheduler/SchedulerTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/scheduler/SchedulerTest.java
@@ -29,6 +29,7 @@ import org.xwiki.test.po.scheduler.SchedulerHomePage;
 import org.xwiki.test.po.scheduler.SchedulerPage;
 import org.xwiki.test.po.scheduler.editor.SchedulerEditPage;
 import org.xwiki.test.ui.AbstractAdminAuthenticatedTest;
+import org.xwiki.test.ui.browser.IgnoreBrowser;
 import org.xwiki.test.ui.po.ViewPage;
 
 /**
@@ -64,6 +65,7 @@ public class SchedulerTest extends AbstractAdminAuthenticatedTest
     }
 
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testJobActions()
     {
         // Create Job

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/tag/AddRemoveTagsTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/tag/AddRemoveTagsTest.java
@@ -25,6 +25,7 @@ import org.apache.commons.lang.RandomStringUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.xwiki.test.ui.AbstractAdminAuthenticatedTest;
+import org.xwiki.test.ui.browser.IgnoreBrowser;
 import org.xwiki.test.po.tag.AddTagsPane;
 import org.xwiki.test.po.tag.TaggablePage;
 
@@ -115,6 +116,7 @@ public class AddRemoveTagsTest extends AbstractAdminAuthenticatedTest
      * Tests that a tag can't be added twice to the same page.
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testAddExistingTag()
     {
         String tag = RandomStringUtils.randomAlphanumeric(4);

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/watchlist/WatchThisPageAndWholeSpaceTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/watchlist/WatchThisPageAndWholeSpaceTest.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 import org.openqa.selenium.By;
 import org.xwiki.test.ui.AbstractAdminAuthenticatedTest;
 import org.xwiki.test.po.administration.ProfileUserProfilePage;
+import org.xwiki.test.ui.browser.IgnoreBrowser;
 import org.xwiki.test.ui.po.ViewPage;
 import org.xwiki.test.po.scheduler.SchedulerHomePage;
 import org.xwiki.test.po.watchlist.WatchlistUserProfilePage;
@@ -82,6 +83,7 @@ public class WatchThisPageAndWholeSpaceTest extends AbstractAdminAuthenticatedTe
     }
 
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testWatchThisPageAndWholeSpace() throws Exception
     {
         // Clear the list of watched documents and spaces

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/xe/DocumentIndexAttachmentsTabFilterTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/xe/DocumentIndexAttachmentsTabFilterTest.java
@@ -27,6 +27,7 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.xwiki.index.test.po.AllDocsPage;
 import org.xwiki.test.ui.AbstractAdminAuthenticatedTest;
+import org.xwiki.test.ui.browser.IgnoreBrowser;
 import org.xwiki.test.ui.po.LiveTableElement;
 
 /**
@@ -46,6 +47,7 @@ public class DocumentIndexAttachmentsTabFilterTest extends AbstractAdminAuthenti
     // WARN: calling isReady() and waitUntilReady() from LiveTableElement.java inside this class fails.
     // Used example from JIRA issue
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testAttachmentsPane()
     {
         AllDocsPage docsPage = AllDocsPage.gotoPage();

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/xe/SpacesTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/xe/SpacesTest.java
@@ -22,6 +22,7 @@ package org.xwiki.test.ui.xe;
 import org.junit.Assert;
 import org.junit.Test;
 import org.xwiki.test.ui.AbstractAdminAuthenticatedTest;
+import org.xwiki.test.ui.browser.IgnoreBrowser;
 import org.xwiki.test.ui.po.editor.WYSIWYGEditPage;
 import org.xwiki.test.ui.po.editor.WikiEditPage;
 import org.xwiki.test.po.xe.HomePage;
@@ -38,6 +39,7 @@ public class SpacesTest extends AbstractAdminAuthenticatedTest
      * Tests if a new space can be created from the Space dashboard.
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testCreateSpace()
     {
         HomePage homePage = HomePage.gotoPage();
@@ -52,6 +54,7 @@ public class SpacesTest extends AbstractAdminAuthenticatedTest
     }
 
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
     public void testLinkToSpaceIndexWhenSpecialCharacterInSpaceName()
     {
         String spaceName = getTestClassName() + "&";


### PR DESCRIPTION
XE-1147: Exclude failing Selenium 2 tests on IE8 from running
