### PR TITLE
Add target attachment document support to XWiki.AttachmentSelector macro and sort by filename

### DIFF
--- a/xwiki-enterprise-ui/src/main/resources/XWiki/AttachmentSelector.xml
+++ b/xwiki-enterprise-ui/src/main/resources/XWiki/AttachmentSelector.xml
@@ -1099,7 +1099,7 @@ $xwiki.jsfx.use('js/scriptaculous/builder.js')##
       <defaultCategory/>
     </property>
     <property>
-      <description>A control to be used for object properties that are supposed to contain the name of an attachment of the containing document.</description>
+      <description>A control to be used for object properties of the current document that are supposed to contain the name of an attachment from the current (or target) document. Allows uploading new attachments, and deleting attachments from the target document.  If no target document is specified, the current document will be used. Object properties are only saved to the current document.</description>
     </property>
     <property>
       <id>attachmentSelector</id>

--- a/xwiki-enterprise-ui/src/main/resources/XWiki/AttachmentSelector.xml
+++ b/xwiki-enterprise-ui/src/main/resources/XWiki/AttachmentSelector.xml
@@ -2079,7 +2079,7 @@ $xwiki.jsx.use($attachmentPickerDocName)
   #end
   (% class="gallery" %)(((
   ## Only display the upload form if they have edit permission on targetAttachDocument
-  #if ($xwiki.hasAccessLevel('edit',$xcontext.user,${targetAttachDocument})))
+  #if ($xwiki.hasAccessLevel('edit',$xcontext.user,${targetAttachDocument.fullName}))
     #attachmentPicker_displayUploadForm($targetDocument, $targetAttachDocument, $options)
   #end
   #attachmentPicker_displayAttachmentGalleryEmptyValue($targetDocument, $targetAttachDocument, $options, $currentValue)

--- a/xwiki-enterprise-ui/src/main/resources/XWiki/AttachmentSelector.xml
+++ b/xwiki-enterprise-ui/src/main/resources/XWiki/AttachmentSelector.xml
@@ -963,9 +963,6 @@ $xwiki.jsfx.use('js/scriptaculous/builder.js')##
 ##
 ## Prepare parameters
 ##
-## Assume we the user has edit and view permissions for targetdocname
-#set ($targetPermView = true)
-#set ($targetPermEdit = true)
 ## Keep track for when we have a target document
 #set ($hasTargetDoc = false)
 #set ($targetdoc = "$!{xcontext.macro.params.targetdocname}")
@@ -978,6 +975,9 @@ $xwiki.jsfx.use('js/scriptaculous/builder.js')##
   #set ($targetdoc = $xwiki.getDocument($targetdoc) )
   #set ($hasTargetDoc = true)
 #else
+  ## The user should have edit and view permissions for the current doc
+  #set ($targetPermView = true)
+  #set ($targetPermEdit = true)
   #set($targetdoc = $doc)
 #end
 #set ($classname = "$!{xcontext.macro.params.classname}")

--- a/xwiki-enterprise-ui/src/main/resources/XWiki/AttachmentSelector.xml
+++ b/xwiki-enterprise-ui/src/main/resources/XWiki/AttachmentSelector.xml
@@ -2083,7 +2083,7 @@ $xwiki.jsx.use($attachmentPickerDocName)
     #attachmentPicker_displayUploadForm($targetDocument, $targetAttachDocument, $options)
   #end
   #attachmentPicker_displayAttachmentGalleryEmptyValue($targetDocument, $targetAttachDocument, $options, $currentValue)
-  #set ($sortedAttachments = $sorttool.sort($targetAttachDocument.getAttachmentList(), 'date:desc') )
+  #set ($sortedAttachments = $sorttool.sort($targetAttachDocument.getAttachmentList(), "${options.sortAttachmentsBy}") )
   #foreach ($attachment in $sortedAttachments)
     #set ($extension = $attachment.getFilename())
     #set ($extension = $extension.substring($mathtool.add($extension.lastIndexOf('.'), 1)).toLowerCase())
@@ -2281,6 +2281,21 @@ $xwiki.jsx.use($attachmentPickerDocName)
   #else
     #set ($displayImage = false)
   #end
+  ### Determine attachment sorting
+  #set($sortAttachmentsBy = "$!{request.sortAttachmentsBy}")
+  #set ($validAttachmentProperties = ['filename', 'date', 'filesize', 'author', 'version', 'mimeType'])
+  #if($sortAttachmentsBy == '' || $validAttachmentProperties.indexOf($sortAttachmentsBy) == -1)
+    ### Default to sorting by filename, sort not requested.
+    #set($sortAttachmentsBy = "filename")
+  #end
+  ### Set attachment sorting direction
+  #if($sortAttachmentsBy == 'date')
+    ### Sort the date descending
+    #set($sortAttachmentsBy = "date:desc")
+  #else
+    ### Sort everything else ascending
+    #set($sortAttachmentsBy = "${sortAttachmentsBy}:asc")
+  #end
   #set ($options = {
     'classname' : ${request.get('classname')},
     'object' : $!{mathtool.toInteger($request.object)},
@@ -2289,7 +2304,8 @@ $xwiki.jsx.use($attachmentPickerDocName)
     'docAction' : ${docAction},
     'defaultValue' : "$!{request.defaultValue}",
     'rawfilter': "$!{rawfilter}",
-    'filter': ${filter}
+    'filter': ${filter},
+    'sortAttachmentsBy': ${sortAttachmentsBy}
   })
   $!targetDocument.use($targetDocument.getObject($options.classname, $options.object))##
   #attachmentPicker_displayAttachmentGallery($targetDocument, $targetAttachDocument, $options)

--- a/xwiki-enterprise-ui/src/main/resources/XWiki/AttachmentSelector.xml
+++ b/xwiki-enterprise-ui/src/main/resources/XWiki/AttachmentSelector.xml
@@ -21,7 +21,7 @@
   <validationScript/>
   <comment/>
   <minorEdit>false</minorEdit>
-  <syntaxId>xwiki/2.0</syntaxId>
+  <syntaxId>xwiki/2.1</syntaxId>
   <hidden>true</hidden>
   <object>
     <class>
@@ -1072,7 +1072,7 @@ $xwiki.jsfx.use('js/scriptaculous/builder.js')##
 ##  1. Edit the current page
 ##  2. View the target attachment page. (can be the same page)
 #macro (attachmentPicker_displayButton)
-  #if ($hasEdit &amp;&amp; $targetPermView)(% class="buttonwrapper" %)[[${buttontext}&gt;&gt;${xcontext.macro.doc.fullName}?#if ($hasTargetDoc)targetdocname=${escapetool.url($targetdoc.fullName)}&amp;#{end}docname=${escapetool.url($doc.fullName)}&amp;classname=${classname}&amp;property=${property}&amp;object=${object}&amp;savemode=${savemode}&amp;defaultValue=$escapetool.url($defaultValue)&amp;filter=$!{filter}&amp;displayImage=${displayImage}||class="attachment-picker-start button" title="${buttontext}"]](%%)#end
+  #if ($hasEdit &amp;&amp; $targetPermView)(% class="buttonwrapper" %)[[${buttontext}&gt;&gt;${xcontext.macro.doc.fullName}||queryString="#if ($hasTargetDoc)targetdocname=${escapetool.url($targetdoc.fullName)}&amp;#{end}docname=${escapetool.url($doc.fullName)}&amp;classname=${classname}&amp;property=${property}&amp;object=${object}&amp;savemode=${savemode}&amp;defaultValue=$escapetool.url($defaultValue)&amp;filter=$!{filter}&amp;displayImage=${displayImage}" class="attachment-picker-start button" title="${buttontext}"]](%%)#end
 #end
 {{/velocity}}
 
@@ -2168,7 +2168,8 @@ $xwiki.jsx.use($attachmentPickerDocName)
     )))## attachmentframe
     (% class="gallery_actions" %)(((
       #foreach ($action in $actions)
-        {{html}}&lt;a href="${action.url}" class="tool ${action.name}" title="$msg.get("${translationPrefix}.actions.${action.name}")" #if($action.rel) rel="${action.rel}"#end&gt;$msg.get("${translationPrefix}.actions.${action.name}")&lt;/a&gt;{{/html}} ##
+        #set( $actionname = $msg.get("${translationPrefix}.actions.${action.name}") )
+        [[${actionname}&gt;&gt;path:${action.url}||class="tool ${action.name}" title="${actionname}" #if($action.rel) rel="${action.rel}"#end]]##
       #end
     )))## actions
   )))## attachmentbox

--- a/xwiki-enterprise-ui/src/main/resources/XWiki/AttachmentSelector.xml
+++ b/xwiki-enterprise-ui/src/main/resources/XWiki/AttachmentSelector.xml
@@ -2,7 +2,7 @@
 
 <xwikidoc>
   <web>XWiki</web>
-  <name>AttachmentSelector</name>
+  <name>AttachmentSelectorT</name>
   <language/>
   <defaultLanguage/>
   <translation>0</translation>
@@ -95,7 +95,7 @@
         <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </use>
     </class>
-    <name>XWiki.AttachmentSelector</name>
+    <name>XWiki.AttachmentSelectorT</name>
     <number>0</number>
     <className>XWiki.JavaScriptExtension</className>
     <guid>caa5337b-fad4-4c21-8ef4-9e7e1c44dbfe</guid>
@@ -486,7 +486,7 @@
         <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </use>
     </class>
-    <name>XWiki.AttachmentSelector</name>
+    <name>XWiki.AttachmentSelectorT</name>
     <number>1</number>
     <className>XWiki.JavaScriptExtension</className>
     <guid>2aa565e6-b9bd-4095-a7a9-bbf47d75d079</guid>
@@ -611,7 +611,7 @@ XWiki.widgets.ModalPopup.prototype.closeDialog = function(event) {
         <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </use>
     </class>
-    <name>XWiki.AttachmentSelector</name>
+    <name>XWiki.AttachmentSelectorT</name>
     <number>0</number>
     <className>XWiki.StyleSheetExtension</className>
     <guid>2a28ce9c-ab00-4847-936d-53e4f2acbfe0</guid>
@@ -943,7 +943,7 @@ XWiki.widgets.ModalPopup.prototype.closeDialog = function(event) {
         <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </visibility>
     </class>
-    <name>XWiki.AttachmentSelector</name>
+    <name>XWiki.AttachmentSelectorT</name>
     <number>0</number>
     <className>XWiki.WikiMacroClass</className>
     <guid>7f67fdfc-a67a-4166-b7c1-6d572ee54719</guid>
@@ -963,6 +963,20 @@ $xwiki.jsfx.use('js/scriptaculous/builder.js')##
 ##
 ## Prepare parameters
 ##
+## Set the targetdoc we want to save to (default to current doc if not set)
+#set ($targetPermView = true)
+#set ($targetPermEdit = true)
+#set ($hasTargetDoc = false)
+#set ($targetdoc = "$!{xcontext.macro.params.targetdocname}")
+#if ("$!{targetdoc}" != '')
+  ## Check access on target
+  #set ($targetPermView = $xwiki.hasAccessLevel('view',$xcontext.user,${targetdoc}))
+  #set ($targetPermEdit = $xwiki.hasAccessLevel('edit',$xcontext.user,${targetdoc}))
+  #set ($targetdoc = $xwiki.getDocument(${targetdoc}) )
+  #set ($hasTargetDoc = true)
+#else
+  #set($targetdoc = $doc)
+#end
 #set ($classname = "$!{xcontext.macro.params.classname}")
 #set ($property = "$!{xcontext.macro.params.property}")
 #set ($object = $mathtool.toInteger("$!{xcontext.macro.params.object}"))
@@ -973,7 +987,7 @@ $xwiki.jsfx.use('js/scriptaculous/builder.js')##
   #end
 #end
 
-#if ("$!{xcontext.macro.params.displayImage}" == 'true')
+#if ("$!{xcontext.macro.params.displayImage}" == 'true' &amp;&amp; $targetPermView)
   #set ($displayImage = true)
 #else
   #set ($displayImage = false)
@@ -1022,16 +1036,16 @@ $xwiki.jsfx.use('js/scriptaculous/builder.js')##
 ##
 
 #macro (attachmentPicker_displayAttachment $name $displayImage $withLink $forceElement)
-  #set ($attachment = $doc.getAttachment("$!{name}"))
+  #set ($attachment = $targetdoc.getAttachment("$!{name}"))
   #if ("$!{name}" != '' &amp;&amp; "$!{attachment}" != '')
-    #set ($attachmentRef = $services.model.createAttachmentReference(${doc.documentReference}, ${name}))
+    #set ($attachmentRef = $services.model.createAttachmentReference(${targetdoc.documentReference}, ${name}))
     #set ($attachmentName = $name)
   #else
     #set ($attachmentRef = $defaultReference)
     #if ($attachmentRef)
       #set ($docReference = $attachmentRef.documentReference)
     #else
-      #set ($docReference = $doc.documentReference)
+      #set ($docReference = $targetdoc.documentReference)
     #end
     #set ($attachmentName = $attachmentRef.name)
     #set ($attachment = $xwiki.getDocument($docReference).getAttachment($attachmentName))
@@ -1044,15 +1058,15 @@ $xwiki.jsfx.use('js/scriptaculous/builder.js')##
   #else
     #set ($attachmentResource = '')
   #end
-  #if ($displayImage)## &amp;&amp; $attachment &amp;&amp; $attachment.isImage())
+  #if ($displayImage)
     (% class="$!{cssClass}#if (!$attachment) hidden#end" %)(((#if ("$!{attachmentResource}" != '' || $forceElement)#if($withLink)[[#end[[image:${attachmentResource}$!{imageParams}]]#if($withLink)&gt;&gt;attach:${attachmentResource}||rel=lightbox]]#{end}#end)))##
   #else
-    (% class="$!{cssClass}" %)#if ("$!{attachmentResource}" != '' || $forceElement)#if ($withLink)[[attach:${attachmentResource}||rel=__blank]]#{else}(% class="displayed" %)${attachmentName}(% %)#{end}#end(%%)##
+    (% class="$!{cssClass}" %)#if ("$!{attachmentResource}" != '' || $forceElement)#if ($withLink)[[attach:${attachmentResource}||rel=__blank]]#{else}(% class="displayed" %)#if($targetPermView)$!{attachmentName}#{else}Access Denied#{end}(% %)#{end}#end(%%)##
   #end
 #end
 
 #macro (attachmentPicker_displayButton)
-  #if ($hasEdit)(% class="buttonwrapper" %)[[${buttontext}&gt;&gt;${xcontext.macro.doc.fullName}?docname=${escapetool.url($doc.fullName)}&amp;classname=${classname}&amp;property=${property}&amp;object=${object}&amp;savemode=${savemode}&amp;defaultValue=$escapetool.url($defaultValue)&amp;filter=$!{filter}&amp;displayImage=${displayImage}||class="attachment-picker-start button" title="${buttontext}"]](%%)#end
+  #if ($hasEdit &amp;&amp; $targetPermEdit &amp;&amp; $targetPermView)(% class="buttonwrapper" %)[[${buttontext}&gt;&gt;${xcontext.macro.doc.fullName}?#if ($hasTargetDoc)targetdocname=${escapetool.url($targetdoc.fullName)}&amp;#{end}docname=${escapetool.url($doc.fullName)}&amp;classname=${classname}&amp;property=${property}&amp;object=${object}&amp;savemode=${savemode}&amp;defaultValue=$escapetool.url($defaultValue)&amp;filter=$!{filter}&amp;displayImage=${displayImage}||class="attachment-picker-start button" title="${buttontext}"]](%%)#end
 #end
 {{/velocity}}
 
@@ -1082,7 +1096,7 @@ $xwiki.jsfx.use('js/scriptaculous/builder.js')##
       <description>A control to be used for object properties that are supposed to contain the name of an attachment of the containing document.</description>
     </property>
     <property>
-      <id>attachmentSelector</id>
+      <id>attachmentSelectorT</id>
     </property>
     <property>
       <name>Attachment Selector</name>
@@ -1143,7 +1157,7 @@ $xwiki.jsfx.use('js/scriptaculous/builder.js')##
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </name>
     </class>
-    <name>XWiki.AttachmentSelector</name>
+    <name>XWiki.AttachmentSelectorT</name>
     <number>0</number>
     <className>XWiki.WikiMacroParameterClass</className>
     <guid>bb1b9208-3b4a-43e4-8a69-603281ca1412</guid>
@@ -1209,7 +1223,7 @@ $xwiki.jsfx.use('js/scriptaculous/builder.js')##
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </name>
     </class>
-    <name>XWiki.AttachmentSelector</name>
+    <name>XWiki.AttachmentSelectorT</name>
     <number>1</number>
     <className>XWiki.WikiMacroParameterClass</className>
     <guid>c51517fc-93e9-4594-8b10-b014a8907452</guid>
@@ -1275,7 +1289,7 @@ $xwiki.jsfx.use('js/scriptaculous/builder.js')##
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </name>
     </class>
-    <name>XWiki.AttachmentSelector</name>
+    <name>XWiki.AttachmentSelectorT</name>
     <number>2</number>
     <className>XWiki.WikiMacroParameterClass</className>
     <guid>b43c2df7-9941-4941-834b-0236424cfaa9</guid>
@@ -1341,7 +1355,7 @@ $xwiki.jsfx.use('js/scriptaculous/builder.js')##
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </name>
     </class>
-    <name>XWiki.AttachmentSelector</name>
+    <name>XWiki.AttachmentSelectorT</name>
     <number>5</number>
     <className>XWiki.WikiMacroParameterClass</className>
     <guid>a35e6fcc-b5e9-4c49-a601-cead93cba813</guid>
@@ -1407,7 +1421,7 @@ $xwiki.jsfx.use('js/scriptaculous/builder.js')##
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </name>
     </class>
-    <name>XWiki.AttachmentSelector</name>
+    <name>XWiki.AttachmentSelectorT</name>
     <number>6</number>
     <className>XWiki.WikiMacroParameterClass</className>
     <guid>2dcec651-66b9-4d7c-9ac6-2578a426a5f4</guid>
@@ -1473,7 +1487,7 @@ $xwiki.jsfx.use('js/scriptaculous/builder.js')##
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </name>
     </class>
-    <name>XWiki.AttachmentSelector</name>
+    <name>XWiki.AttachmentSelectorT</name>
     <number>7</number>
     <className>XWiki.WikiMacroParameterClass</className>
     <guid>a932ece6-3c6d-48c7-a717-536317705f71</guid>
@@ -1539,7 +1553,7 @@ $xwiki.jsfx.use('js/scriptaculous/builder.js')##
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </name>
     </class>
-    <name>XWiki.AttachmentSelector</name>
+    <name>XWiki.AttachmentSelectorT</name>
     <number>10</number>
     <className>XWiki.WikiMacroParameterClass</className>
     <guid>5c3f5b0d-1d0d-4820-8985-13d779972acb</guid>
@@ -1605,7 +1619,7 @@ $xwiki.jsfx.use('js/scriptaculous/builder.js')##
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </name>
     </class>
-    <name>XWiki.AttachmentSelector</name>
+    <name>XWiki.AttachmentSelectorT</name>
     <number>12</number>
     <className>XWiki.WikiMacroParameterClass</className>
     <guid>aa252c40-59a0-4e82-a94b-e133862fe082</guid>
@@ -1671,7 +1685,7 @@ $xwiki.jsfx.use('js/scriptaculous/builder.js')##
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </name>
     </class>
-    <name>XWiki.AttachmentSelector</name>
+    <name>XWiki.AttachmentSelectorT</name>
     <number>13</number>
     <className>XWiki.WikiMacroParameterClass</className>
     <guid>e31c42de-47d7-4a73-a236-b99c2231dca7</guid>
@@ -1737,7 +1751,7 @@ $xwiki.jsfx.use('js/scriptaculous/builder.js')##
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </name>
     </class>
-    <name>XWiki.AttachmentSelector</name>
+    <name>XWiki.AttachmentSelectorT</name>
     <number>14</number>
     <className>XWiki.WikiMacroParameterClass</className>
     <guid>0b2cea67-1942-4ce2-9f5e-90907033c92c</guid>
@@ -1803,7 +1817,7 @@ $xwiki.jsfx.use('js/scriptaculous/builder.js')##
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </name>
     </class>
-    <name>XWiki.AttachmentSelector</name>
+    <name>XWiki.AttachmentSelectorT</name>
     <number>15</number>
     <className>XWiki.WikiMacroParameterClass</className>
     <guid>003ab606-5c72-465d-bfd6-bd21262be502</guid>
@@ -1869,7 +1883,7 @@ $xwiki.jsfx.use('js/scriptaculous/builder.js')##
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </name>
     </class>
-    <name>XWiki.AttachmentSelector</name>
+    <name>XWiki.AttachmentSelectorT</name>
     <number>16</number>
     <className>XWiki.WikiMacroParameterClass</className>
     <guid>9ca8402c-6df8-4068-b00f-1f9bb18f38a9</guid>
@@ -1935,7 +1949,7 @@ $xwiki.jsfx.use('js/scriptaculous/builder.js')##
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </name>
     </class>
-    <name>XWiki.AttachmentSelector</name>
+    <name>XWiki.AttachmentSelectorT</name>
     <number>17</number>
     <className>XWiki.WikiMacroParameterClass</className>
     <guid>54e733cd-f755-4dee-8629-b713f685790a</guid>
@@ -1955,9 +1969,11 @@ $xwiki.jsfx.use('js/scriptaculous/builder.js')##
   <content>{{velocity output="false"}}
 #if ($request.xaction == 'postUpload')
   #set ($targetDocument = $xwiki.getDocument($request.get('docname')))
+  #set ($targetAttachDocument = $xwiki.getDocument($request.get('targetdocname')))
+  
   #set ($fieldname = $request.get('fieldname'))
   #set ($docAction = $request.get('docAction'))
-  #set ($attachmentList = $targetDocument.getAttachmentList())
+  #set ($attachmentList = $targetAttachDocument.getAttachmentList())
   #if ($attachmentList &amp;&amp; $attachmentList.size() &gt; 0)
     #set ($sortedAttachments = $sorttool.sort($attachmentList, 'date:desc'))
     #set ($lastAttachment = $sortedAttachments.get(0))
@@ -1972,7 +1988,7 @@ $xwiki.jsfx.use('js/scriptaculous/builder.js')##
 ## Macros
 ##
 #set ($translationPrefix = 'xe.attachmentSelector')
-#set ($attachmentPickerDocName = 'XWiki.AttachmentSelector')
+#set ($attachmentPickerDocName = 'XWiki.AttachmentSelectorT')
 
 $xwiki.ssx.use($attachmentPickerDocName)
 $xwiki.jsx.use($attachmentPickerDocName)
@@ -1980,23 +1996,24 @@ $xwiki.jsx.use($attachmentPickerDocName)
 #**
  * Displays the attachment gallery as a list of attachment boxes, starting with special boxes for uploading a new attachment and for setting a default value.
  * 
- * @param $targetDocument the document being modified
+ * @param $targetDocument the document to recieve the field value being modified
+ * @param $targetAttachDocument the document to list/save attachments to
  * @param $options generic picker options
  *#
-#macro (attachmentPicker_displayAttachmentGallery $targetDocument, $options)
+#macro (attachmentPicker_displayAttachmentGallery $targetDocument, $targetAttachDocument, $options)
   #set ($currentValue = $targetDocument.getValue($options.property))
-  #if ("$!{targetDocument.getAttachment($currentValue)}" == '')
+  #if ("$!{targetAttachDocument.getAttachment($currentValue)}" == '')
     #set ($currentValue = "$!{options.defaultValue}")
   #end
   (% class="gallery" %)(((
-  #attachmentPicker_displayUploadForm($targetDocument, $options)
-  #attachmentPicker_displayAttachmentGalleryEmptyValue($targetDocument, $options, $currentValue)
-  #set ($sortedAttachments = $sorttool.sort($targetDocument.getAttachmentList(), 'date:desc') )
+  #attachmentPicker_displayUploadForm($targetDocument, $targetAttachDocument, $options)
+  #attachmentPicker_displayAttachmentGalleryEmptyValue($targetDocument, $targetAttachDocument, $options, $currentValue)
+  #set ($sortedAttachments = $sorttool.sort($targetAttachDocument.getAttachmentList(), 'date:desc') )
   #foreach ($attachment in $sortedAttachments)
     #set ($extension = $attachment.getFilename())
     #set ($extension = $extension.substring($mathtool.add($extension.lastIndexOf('.'), 1)).toLowerCase())
     #if ($options.filter.size() == 0 || $options.filter.contains($extension))
-      #attachmentPicker_displayAttachment($attachment $targetDocument, $options $currentValue)
+      #attachmentPicker_displayAttachmentBox($attachment $targetDocument $targetAttachDocument, $options $currentValue)
     #end
   #end
   )))
@@ -2010,17 +2027,17 @@ $xwiki.jsx.use($attachmentPickerDocName)
  * @param $options generic picker options
  * @param $currentValue the currently selected file, used for determining if the box should be highlighted as the current value
  *#
-#macro (attachmentPicker_displayAttachment $attachment $targetDocument, $options $currentValue)
+#macro (attachmentPicker_displayAttachmentBox $attachment $targetDocument $targetAttachDocument, $options $currentValue)
   #if ($options.displayImage &amp;&amp; $attachment.isImage())
     #set ($cssClass = 'gallery_image')
   #else
     #set ($cssClass = '')
-  #end
-  #attachmentPicker_displayStartFrame({'value' : $attachment.filename, 'text' : $attachment.filename, 'cssClass' : "$!{cssClass}"} $targetDocument $currentValue)
+  #end  
+  #attachmentPicker_displayStartFrame({'value' : $attachment.filename, 'text' : $attachment.filename, 'cssClass' : "$!{cssClass}"} $currentValue)
   #attachmentPicker_displayAttachmentDetails($attachment $options)
   #set ($returnURL = $escapetool.url($doc.getURL('view', $request.queryString)))
-  #set ($deleteURL = $targetDocument.getAttachmentURL($attachment.filename, 'delattachment', "xredirect=${returnURL}&amp;form_token=$!{services.csrf.getToken()}") )
-  #set ($viewURL = $targetDocument.getAttachmentURL($attachment.filename) )##{'name' : 'download', 'url' : $viewURL, 'rel' : '__blank'}
+  #set ($deleteURL = $targetAttachDocument.getAttachmentURL($attachment.filename, 'delattachment', "xredirect=${returnURL}&amp;form_token=$!{services.csrf.getToken()}") )
+  #set ($viewURL = $targetAttachDocument.getAttachmentURL($attachment.filename) )##{'name' : 'download', 'url' : $viewURL, 'rel' : '__blank'}
   #set ($selectURL = $targetDocument.getURL(${options.get('docAction')}, "${options.get('classname')}_${options.get('object')}_${options.get('property')}=${attachment.filename}&amp;form_token=$!{services.csrf.getToken()}"))
   #attachmentPicker_displayEndFrame ([{'name' : 'select', 'url' : $selectURL}, {'name' : 'delete', 'url' : $deleteURL}])
 #end
@@ -2030,10 +2047,9 @@ $xwiki.jsx.use($attachmentPickerDocName)
  * 
  * @param $boxOptions a map of parameters/options for the current attachment, holding, for example, the attachment name (boxOptions.value),
  *        the title to display (boxOptions.text), optional extra CSS classnames to put on the box (boxOptions.cssClass)
- * @param $targetDocument the document being modified
  * @param $currentValue the currently selected file, used for determining if this attachment should be highlighted as the current value
  *#
-#macro (attachmentPicker_displayStartFrame $boxOptions $targetDocument $currentValue)
+#macro (attachmentPicker_displayStartFrame $boxOptions $currentValue)
   (% class="gallery_attachmentbox $!{boxOptions.cssClass} #if ("$!{boxOptions.value}" == $currentValue) current#{end}" %)(((
     (% class="gallery_attachmenttitle" title="$!{boxOptions.value}" %)((($boxOptions.text)))
     (% class="gallery_attachmentframe" %)(((
@@ -2086,23 +2102,24 @@ $xwiki.jsx.use($attachmentPickerDocName)
 #**
  * Displays the upload box used for adding and selecting a new attachment.
  * 
- * @param $targetDocument the document being modified
+ * @param $targetDocument the document with the property being modified
+ * @param $targetAttachDocument the document to upload the attachment to
  * @param $options generic picker options
  *#
-#macro (attachmentPicker_displayUploadForm $targetDocument, $options)
+#macro (attachmentPicker_displayUploadForm $targetDocument, $targetAttachDocument, $options)
 #attachmentPicker_displayStartFrame({
    'value' : $msg.get("${translationPrefix}.upload.title"),
    'text' : $msg.get("${translationPrefix}.upload.title"),
    'cssClass' : 'gallery_upload'
-  } $targetDocument $NULL)
+  } $NULL)
 {{html clean="false"}}
-&lt;form action="$targetDocument.getURL('upload')" enctype="multipart/form-data" method="post" id="uploadAttachment" class="uploadAttachment xform"&gt;
+&lt;form action="$targetAttachDocument.getURL('upload')" enctype="multipart/form-data" method="post" id="uploadAttachment" class="uploadAttachment xform"&gt;
   &lt;div class="gallery_upload_input"&gt;
     #if (${options.rawfilter} != '')
       &lt;span class="xHint"&gt;$msg.get("${translationPrefix}.upload.hint", [${options.rawfilter}])&lt;/span&gt;
     #end
     &lt;input type="file" name="filepath" id="attachfile" class="attachment" size="30" title="$!{escapetool.xml($options.rawfilter)}"/&gt;
-    &lt;input type="hidden" name="xredirect" value="$xwiki.getDocument($attachmentPickerDocName).getURL('get', "xaction=postUpload&amp;amp;docAction=$!{escapetool.url($options.get('docAction'))}&amp;amp;docname=$!{escapetool.url($targetDocument.fullName)}&amp;amp;fieldname=$!{escapetool.url($options.get('classname'))}_$!{escapetool.url($options.get('object'))}_$!{escapetool.url($options.get('property'))}&amp;amp;form_token=$!{services.csrf.getToken()}")" /&gt;
+    &lt;input type="hidden" name="xredirect" value="$xwiki.getDocument($attachmentPickerDocName).getURL('get', "xaction=postUpload&amp;amp;docAction=$!{escapetool.url($options.get('docAction'))}&amp;amp;targetdocname=$!{escapetool.url($targetAttachDocument.fullName)}&amp;amp;docname=$!{escapetool.url($targetDocument.fullName)}&amp;amp;fieldname=$!{escapetool.url($options.get('classname'))}_$!{escapetool.url($options.get('object'))}_$!{escapetool.url($options.get('property'))}&amp;amp;form_token=$!{services.csrf.getToken()}")" /&gt;
     &lt;input type="hidden" name="docname" value="$!{escapetool.xml($targetDocument.fullName)}" /&gt;
     &lt;input type="hidden" name="classname" value="$!{escapetool.xml($options.get('classname'))}" /&gt;
     &lt;input type="hidden" name="object" value="$!{escapetool.xml($options.get('object'))}" /&gt;
@@ -2123,17 +2140,18 @@ $xwiki.jsx.use($attachmentPickerDocName)
  * Displays the "empty value" box, used for unsetting the field value.
  * 
  * @param $targetDocument the document being modified
+ * @param $targetAttachDocument the document that the attachments will the loaded from/saved to
  * @param $options generic picker options
  * @param $currentValue the currently selected file, used for determining if the empty box should be highlighted as the current value
  *#
-#macro (attachmentPicker_displayAttachmentGalleryEmptyValue $targetDocument, $options, $currentValue)
+#macro (attachmentPicker_displayAttachmentGalleryEmptyValue $targetDocument, $targetAttachDocument, $options, $currentValue)
   #if ("$!{options.get('defaultValue')}" != '')
     #set ($reference = ${options.get('defaultValue')})
     #set ($docNameLimit = $reference.indexOf('@'))
     #if ($docNameLimit &gt; 0)
       #set ($docName = $reference.substring(0, $docNameLimit))
     #else
-      #set ($docName = $targetDocument.fullName)
+      #set ($docName = $targetAttachDocument.fullName)
     #end
     #set ($attachmentName = $reference.substring($mathtool.add($docNameLimit, 1)))
     #set ($defaultAttachment = $xwiki.getDocument($docName).getAttachment($attachmentName))
@@ -2141,7 +2159,7 @@ $xwiki.jsx.use($attachmentPickerDocName)
       #set($dcssClass = 'gallery_image')
     #end
   #end
-  #attachmentPicker_displayStartFrame({'cssClass' : "gallery_emptyChoice $!{dcssClass}", 'text' : $msg.get("${translationPrefix}.default"), 'value' : "${options.defaultValue}"} $targetDocument $currentValue)
+  #attachmentPicker_displayStartFrame({'cssClass' : "gallery_emptyChoice $!{dcssClass}", 'text' : $msg.get("${translationPrefix}.default"), 'value' : "${options.defaultValue}"} $currentValue)
   #attachmentPicker_displayAttachmentDetails($defaultAttachment $options)
   #set ($returnURL = $escapetool.url($doc.getURL('view', $request.queryString)))
   #set ($selectURL = $targetDocument.getURL(${options.get('docAction')}, "${options.get('classname')}_${options.get('object')}_${options.get('property')}=&amp;form_token=$!{services.csrf.getToken()}"))
@@ -2157,10 +2175,17 @@ $xwiki.jsx.use($attachmentPickerDocName)
   ##  $response.setContentType('multipart/formdata')
   ###end
   #set ($targetDocument = $xwiki.getDocument($request.docname))
+  #if ($request.targetdocname)
+    ## Use the target document if it exists.
+    #set ($targetAttachDocument = $xwiki.getDocument($request.targetdocname))
+  #else
+    ## Otherwise, just use the current document as the target to save/load attachments
+    #set ($targetAttachDocument = $targetDocument)
+  #end
   #if ("$!{request.savemode}" == 'direct')
     #set($docAction = 'save')
   #else
-    #set($docAction = $targetDocument.getDefaultEditMode())
+    #set($docAction = $targetAttachDocument.getDefaultEditMode())
   #end
   #set ($filter = [])
   #set ($rawfilter = '')
@@ -2191,7 +2216,7 @@ $xwiki.jsx.use($attachmentPickerDocName)
     'filter': ${filter}
   })
   $!targetDocument.use($targetDocument.getObject($options.classname, $options.object))##
-  #attachmentPicker_displayAttachmentGallery($targetDocument, $options)
+  #attachmentPicker_displayAttachmentGallery($targetDocument, $targetAttachDocument, $options)
 
   (% class="gallery_buttons buttons" %)(((
   (% class="buttonwrapper secondary" %)[[$msg.get("${translationPrefix}.cancel")&gt;&gt;$targetDocument||class="button secondary" id="attachment-picker-close"]]

--- a/xwiki-enterprise-ui/src/main/resources/XWiki/AttachmentSelector.xml
+++ b/xwiki-enterprise-ui/src/main/resources/XWiki/AttachmentSelector.xml
@@ -2,7 +2,7 @@
 
 <xwikidoc>
   <web>XWiki</web>
-  <name>AttachmentSelectorT</name>
+  <name>AttachmentSelector</name>
   <language/>
   <defaultLanguage/>
   <translation>0</translation>
@@ -95,7 +95,7 @@
         <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </use>
     </class>
-    <name>XWiki.AttachmentSelectorT</name>
+    <name>XWiki.AttachmentSelector</name>
     <number>0</number>
     <className>XWiki.JavaScriptExtension</className>
     <guid>caa5337b-fad4-4c21-8ef4-9e7e1c44dbfe</guid>
@@ -486,7 +486,7 @@
         <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </use>
     </class>
-    <name>XWiki.AttachmentSelectorT</name>
+    <name>XWiki.AttachmentSelector</name>
     <number>1</number>
     <className>XWiki.JavaScriptExtension</className>
     <guid>2aa565e6-b9bd-4095-a7a9-bbf47d75d079</guid>
@@ -611,7 +611,7 @@ XWiki.widgets.ModalPopup.prototype.closeDialog = function(event) {
         <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </use>
     </class>
-    <name>XWiki.AttachmentSelectorT</name>
+    <name>XWiki.AttachmentSelector</name>
     <number>0</number>
     <className>XWiki.StyleSheetExtension</className>
     <guid>2a28ce9c-ab00-4847-936d-53e4f2acbfe0</guid>
@@ -943,7 +943,7 @@ XWiki.widgets.ModalPopup.prototype.closeDialog = function(event) {
         <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </visibility>
     </class>
-    <name>XWiki.AttachmentSelectorT</name>
+    <name>XWiki.AttachmentSelector</name>
     <number>0</number>
     <className>XWiki.WikiMacroClass</className>
     <guid>7f67fdfc-a67a-4166-b7c1-6d572ee54719</guid>
@@ -963,16 +963,19 @@ $xwiki.jsfx.use('js/scriptaculous/builder.js')##
 ##
 ## Prepare parameters
 ##
-## Set the targetdoc we want to save to (default to current doc if not set)
+## Assume we the user has edit and view permissions for targetdocname
 #set ($targetPermView = true)
 #set ($targetPermEdit = true)
+## Keep track for when we have a target document
 #set ($hasTargetDoc = false)
 #set ($targetdoc = "$!{xcontext.macro.params.targetdocname}")
+###
+## Set the targetdoc we want to save to (default to current doc if not set)
 #if ("$!{targetdoc}" != '')
-  ## Check access on target
+  ## Check access on targetdocname
   #set ($targetPermView = $xwiki.hasAccessLevel('view',$xcontext.user,${targetdoc}))
   #set ($targetPermEdit = $xwiki.hasAccessLevel('edit',$xcontext.user,${targetdoc}))
-  #set ($targetdoc = $xwiki.getDocument(${targetdoc}) )
+  #set ($targetdoc = $xwiki.getDocument($targetdoc) )
   #set ($hasTargetDoc = true)
 #else
   #set($targetdoc = $doc)
@@ -1065,8 +1068,11 @@ $xwiki.jsfx.use('js/scriptaculous/builder.js')##
   #end
 #end
 
+## Display the "Choose an attachment" button if they can:
+##  1. Edit the current page
+##  2. View the target attachment page. (can be the same page)
 #macro (attachmentPicker_displayButton)
-  #if ($hasEdit &amp;&amp; $targetPermEdit &amp;&amp; $targetPermView)(% class="buttonwrapper" %)[[${buttontext}&gt;&gt;${xcontext.macro.doc.fullName}?#if ($hasTargetDoc)targetdocname=${escapetool.url($targetdoc.fullName)}&amp;#{end}docname=${escapetool.url($doc.fullName)}&amp;classname=${classname}&amp;property=${property}&amp;object=${object}&amp;savemode=${savemode}&amp;defaultValue=$escapetool.url($defaultValue)&amp;filter=$!{filter}&amp;displayImage=${displayImage}||class="attachment-picker-start button" title="${buttontext}"]](%%)#end
+  #if ($hasEdit &amp;&amp; $targetPermView)(% class="buttonwrapper" %)[[${buttontext}&gt;&gt;${xcontext.macro.doc.fullName}?#if ($hasTargetDoc)targetdocname=${escapetool.url($targetdoc.fullName)}&amp;#{end}docname=${escapetool.url($doc.fullName)}&amp;classname=${classname}&amp;property=${property}&amp;object=${object}&amp;savemode=${savemode}&amp;defaultValue=$escapetool.url($defaultValue)&amp;filter=$!{filter}&amp;displayImage=${displayImage}||class="attachment-picker-start button" title="${buttontext}"]](%%)#end
 #end
 {{/velocity}}
 
@@ -1096,7 +1102,7 @@ $xwiki.jsfx.use('js/scriptaculous/builder.js')##
       <description>A control to be used for object properties that are supposed to contain the name of an attachment of the containing document.</description>
     </property>
     <property>
-      <id>attachmentSelectorT</id>
+      <id>attachmentSelector</id>
     </property>
     <property>
       <name>Attachment Selector</name>
@@ -1157,7 +1163,7 @@ $xwiki.jsfx.use('js/scriptaculous/builder.js')##
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </name>
     </class>
-    <name>XWiki.AttachmentSelectorT</name>
+    <name>XWiki.AttachmentSelector</name>
     <number>0</number>
     <className>XWiki.WikiMacroParameterClass</className>
     <guid>bb1b9208-3b4a-43e4-8a69-603281ca1412</guid>
@@ -1223,7 +1229,7 @@ $xwiki.jsfx.use('js/scriptaculous/builder.js')##
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </name>
     </class>
-    <name>XWiki.AttachmentSelectorT</name>
+    <name>XWiki.AttachmentSelector</name>
     <number>1</number>
     <className>XWiki.WikiMacroParameterClass</className>
     <guid>c51517fc-93e9-4594-8b10-b014a8907452</guid>
@@ -1289,7 +1295,7 @@ $xwiki.jsfx.use('js/scriptaculous/builder.js')##
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </name>
     </class>
-    <name>XWiki.AttachmentSelectorT</name>
+    <name>XWiki.AttachmentSelector</name>
     <number>2</number>
     <className>XWiki.WikiMacroParameterClass</className>
     <guid>b43c2df7-9941-4941-834b-0236424cfaa9</guid>
@@ -1355,7 +1361,7 @@ $xwiki.jsfx.use('js/scriptaculous/builder.js')##
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </name>
     </class>
-    <name>XWiki.AttachmentSelectorT</name>
+    <name>XWiki.AttachmentSelector</name>
     <number>5</number>
     <className>XWiki.WikiMacroParameterClass</className>
     <guid>a35e6fcc-b5e9-4c49-a601-cead93cba813</guid>
@@ -1421,7 +1427,7 @@ $xwiki.jsfx.use('js/scriptaculous/builder.js')##
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </name>
     </class>
-    <name>XWiki.AttachmentSelectorT</name>
+    <name>XWiki.AttachmentSelector</name>
     <number>6</number>
     <className>XWiki.WikiMacroParameterClass</className>
     <guid>2dcec651-66b9-4d7c-9ac6-2578a426a5f4</guid>
@@ -1487,7 +1493,7 @@ $xwiki.jsfx.use('js/scriptaculous/builder.js')##
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </name>
     </class>
-    <name>XWiki.AttachmentSelectorT</name>
+    <name>XWiki.AttachmentSelector</name>
     <number>7</number>
     <className>XWiki.WikiMacroParameterClass</className>
     <guid>a932ece6-3c6d-48c7-a717-536317705f71</guid>
@@ -1553,7 +1559,7 @@ $xwiki.jsfx.use('js/scriptaculous/builder.js')##
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </name>
     </class>
-    <name>XWiki.AttachmentSelectorT</name>
+    <name>XWiki.AttachmentSelector</name>
     <number>10</number>
     <className>XWiki.WikiMacroParameterClass</className>
     <guid>5c3f5b0d-1d0d-4820-8985-13d779972acb</guid>
@@ -1619,7 +1625,7 @@ $xwiki.jsfx.use('js/scriptaculous/builder.js')##
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </name>
     </class>
-    <name>XWiki.AttachmentSelectorT</name>
+    <name>XWiki.AttachmentSelector</name>
     <number>12</number>
     <className>XWiki.WikiMacroParameterClass</className>
     <guid>aa252c40-59a0-4e82-a94b-e133862fe082</guid>
@@ -1685,7 +1691,7 @@ $xwiki.jsfx.use('js/scriptaculous/builder.js')##
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </name>
     </class>
-    <name>XWiki.AttachmentSelectorT</name>
+    <name>XWiki.AttachmentSelector</name>
     <number>13</number>
     <className>XWiki.WikiMacroParameterClass</className>
     <guid>e31c42de-47d7-4a73-a236-b99c2231dca7</guid>
@@ -1751,7 +1757,7 @@ $xwiki.jsfx.use('js/scriptaculous/builder.js')##
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </name>
     </class>
-    <name>XWiki.AttachmentSelectorT</name>
+    <name>XWiki.AttachmentSelector</name>
     <number>14</number>
     <className>XWiki.WikiMacroParameterClass</className>
     <guid>0b2cea67-1942-4ce2-9f5e-90907033c92c</guid>
@@ -1817,7 +1823,7 @@ $xwiki.jsfx.use('js/scriptaculous/builder.js')##
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </name>
     </class>
-    <name>XWiki.AttachmentSelectorT</name>
+    <name>XWiki.AttachmentSelector</name>
     <number>15</number>
     <className>XWiki.WikiMacroParameterClass</className>
     <guid>003ab606-5c72-465d-bfd6-bd21262be502</guid>
@@ -1883,7 +1889,7 @@ $xwiki.jsfx.use('js/scriptaculous/builder.js')##
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </name>
     </class>
-    <name>XWiki.AttachmentSelectorT</name>
+    <name>XWiki.AttachmentSelector</name>
     <number>16</number>
     <className>XWiki.WikiMacroParameterClass</className>
     <guid>9ca8402c-6df8-4068-b00f-1f9bb18f38a9</guid>
@@ -1949,7 +1955,7 @@ $xwiki.jsfx.use('js/scriptaculous/builder.js')##
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </name>
     </class>
-    <name>XWiki.AttachmentSelectorT</name>
+    <name>XWiki.AttachmentSelector</name>
     <number>17</number>
     <className>XWiki.WikiMacroParameterClass</className>
     <guid>54e733cd-f755-4dee-8629-b713f685790a</guid>
@@ -1964,6 +1970,72 @@ $xwiki.jsfx.use('js/scriptaculous/builder.js')##
     </property>
     <property>
       <name>link</name>
+    </property>
+  </object>
+  <object>
+    <class>
+      <name>XWiki.WikiMacroParameterClass</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb></defaultWeb>
+      <nameField/>
+      <validationScript/>
+      <defaultValue>
+        <disabled>0</disabled>
+        <name>defaultValue</name>
+        <number>4</number>
+        <prettyName>Parameter default value</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </defaultValue>
+      <description>
+        <disabled>0</disabled>
+        <name>description</name>
+        <number>2</number>
+        <prettyName>Parameter description</prettyName>
+        <rows>5</rows>
+        <size>40</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </description>
+      <mandatory>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType>yesno</displayType>
+        <name>mandatory</name>
+        <number>3</number>
+        <prettyName>Parameter mandatory</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </mandatory>
+      <name>
+        <disabled>0</disabled>
+        <name>name</name>
+        <number>1</number>
+        <prettyName>Parameter name</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </name>
+    </class>
+    <name>XWiki.AttachmentSelector</name>
+    <number>18</number>
+    <className>XWiki.WikiMacroParameterClass</className>
+    <guid>99b73453-120c-481a-8889-1a7efc7b73f2</guid>
+    <property>
+      <defaultValue></defaultValue>
+    </property>
+    <property>
+      <description>The target document name to save/list attachments from</description>
+    </property>
+    <property>
+      <mandatory>0</mandatory>
+    </property>
+    <property>
+      <name>targetdocname</name>
     </property>
   </object>
   <content>{{velocity output="false"}}
@@ -1988,7 +2060,7 @@ $xwiki.jsfx.use('js/scriptaculous/builder.js')##
 ## Macros
 ##
 #set ($translationPrefix = 'xe.attachmentSelector')
-#set ($attachmentPickerDocName = 'XWiki.AttachmentSelectorT')
+#set ($attachmentPickerDocName = 'XWiki.AttachmentSelector')
 
 $xwiki.ssx.use($attachmentPickerDocName)
 $xwiki.jsx.use($attachmentPickerDocName)
@@ -2006,7 +2078,10 @@ $xwiki.jsx.use($attachmentPickerDocName)
     #set ($currentValue = "$!{options.defaultValue}")
   #end
   (% class="gallery" %)(((
-  #attachmentPicker_displayUploadForm($targetDocument, $targetAttachDocument, $options)
+  ## Only display the upload form if they have edit permission on targetAttachDocument
+  #if ($xwiki.hasAccessLevel('edit',$xcontext.user,${targetAttachDocument})))
+    #attachmentPicker_displayUploadForm($targetDocument, $targetAttachDocument, $options)
+  #end
   #attachmentPicker_displayAttachmentGalleryEmptyValue($targetDocument, $targetAttachDocument, $options, $currentValue)
   #set ($sortedAttachments = $sorttool.sort($targetAttachDocument.getAttachmentList(), 'date:desc') )
   #foreach ($attachment in $sortedAttachments)


### PR DESCRIPTION
Hello, this is a pull request for the following improvement added to the JIRA:

http://jira.xwiki.org/browse/XE-1169

I've tested it against XE 3.5 and it works nicely with a target attachment document, or defaults back to the current document and works like it used to if the targetdocname macro parameter is not set.

Also default to sorting the attachment listing by filename, and also can take sortAttachmentsBy request parameter.  Could add additional macro parameter later, or allow user to choose how to sort with changed UI.

Feel free to include this under any license.

Jamie
