### PR TITLE
XWIKI-7679: Separate Message Stream input from Activity Stream

### DIFF
--- a/xwiki-enterprise-ui/src/main/resources/Main/Activity.xml
+++ b/xwiki-enterprise-ui/src/main/resources/Main/Activity.xml
@@ -117,7 +117,7 @@ XWiki.Activity = Class.create({
       }
     }.bind(this));
 
-    document.observe('xwiki:messagestream:messageSent', function(event) {
+    document.observe('xwiki:activity:newActivity', function(event) {
       // Update all activity streams to display the new message
       $$('.activity').each(this.updateActivity.bind(this));
     }.bind(this));

--- a/xwiki-enterprise-ui/src/main/resources/Main/MessageSenderMacro.xml
+++ b/xwiki-enterprise-ui/src/main/resources/Main/MessageSenderMacro.xml
@@ -183,8 +183,8 @@ XWiki.MessageStream = Class.create({
                 msForm._notification.hide();
               }
               msForm._notification = new XWiki.widgets.Notification("$msg.get('xe.activity.messages.submit.success')", 'done');
-              
-              document.fire('xwiki:messagestream:messageSent', msForm);
+
+              document.fire('xwiki:activity:newActivity', msForm);
             },
             onFailure: function(response) {
               var failureReason = '';


### PR DESCRIPTION
- Activity macro displays by default the new messageSender macro (can be disabled using messageSender='false')
- Handling delete message actions in the activity macro
- Handling post message actions in the messgeSender macro
- Posting a message is now a 2 step process: 1) send message; 2) refresh the activity stream
- Better w/o JavaScript and server-side handling
- Avoided displaying the macro UI when performing AJAX or xredirect calls
- Error handling improvements
