### PR TITLE
XE-1176: Exclude failing Selenium 2 tests on IE9 from running

### DIFF
--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/AttachmentTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/AttachmentTest.java
@@ -25,6 +25,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.xwiki.test.ui.browser.IgnoreBrowser;
+import org.xwiki.test.ui.browser.IgnoreBrowsers;
 import org.xwiki.test.ui.po.AttachmentsPane;
 import org.xwiki.test.ui.po.ViewPage;
 
@@ -52,7 +53,10 @@ public class AttachmentTest extends AbstractAdminAuthenticatedTest
     }
 
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testUploadDownloadTwoAttachments()
     {
         ViewPage vp = getUtil().createPage(getTestClassName(), getTestMethodName(), null,
@@ -85,7 +89,10 @@ public class AttachmentTest extends AbstractAdminAuthenticatedTest
      * See XWIKI-5896: The image handling in the WYSIWYG-editor with GIF images is buggy.
      */
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testAttachAndViewGifImage()
     {
         // Prepare the page to display the GIF image. We explicitly set the width to a value greater than the actual

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/BreadcrumbsTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/BreadcrumbsTest.java
@@ -23,6 +23,7 @@ import junit.framework.Assert;
 
 import org.junit.Test;
 import org.xwiki.test.ui.browser.IgnoreBrowser;
+import org.xwiki.test.ui.browser.IgnoreBrowsers;
 import org.xwiki.test.ui.po.ViewPage;
 
 /**
@@ -38,7 +39,10 @@ public class BreadcrumbsTest extends AbstractAdminAuthenticatedTest
     private static final String CHILD_TITLE = "Child page";
 
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testBreadcrumbs()
     {
         // Delete the page to reset the rights on it (since the test below modifies them).

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/CommentAsGuestTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/CommentAsGuestTest.java
@@ -25,6 +25,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.xwiki.test.po.administration.GlobalRightsAdministrationSectionPage;
 import org.xwiki.test.ui.browser.IgnoreBrowser;
+import org.xwiki.test.ui.browser.IgnoreBrowsers;
 import org.xwiki.test.ui.po.CommentsTab;
 import org.xwiki.test.ui.po.ViewPage;
 import org.xwiki.test.ui.po.EditRightsPane.Right;
@@ -81,7 +82,10 @@ public class CommentAsGuestTest extends AbstractAdminAuthenticatedTest
     }
 
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testPostCommentAsGuest()
     {
         CommentsTab commentsTab = this.vp.openCommentsDocExtraPane();
@@ -92,7 +96,10 @@ public class CommentAsGuestTest extends AbstractAdminAuthenticatedTest
     }
 
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testPostCommentAsGuestNoJs()
     {
         getUtil().gotoPage(SPACE_NAME, DOC_NAME, "view", "xpage=xpart&vm=commentsinline.vm");
@@ -108,7 +115,10 @@ public class CommentAsGuestTest extends AbstractAdminAuthenticatedTest
     }
 
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testReplyCommentAsAnonymous()
     {
         CommentsTab commentsTab = this.vp.openCommentsDocExtraPane();
@@ -122,7 +132,10 @@ public class CommentAsGuestTest extends AbstractAdminAuthenticatedTest
     }
 
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testCannotEditCommentAsAnonymous()
     {
         CommentsTab commentsTab = this.vp.openCommentsDocExtraPane();

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/CreatePageTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/CreatePageTest.java
@@ -30,6 +30,7 @@ import org.xwiki.test.po.administration.TemplateProviderInlinePage;
 import org.xwiki.test.po.administration.TemplatesAdministrationSectionPage;
 import org.xwiki.test.po.xe.HomePage;
 import org.xwiki.test.ui.browser.IgnoreBrowser;
+import org.xwiki.test.ui.browser.IgnoreBrowsers;
 import org.xwiki.test.ui.po.CreatePagePage;
 import org.xwiki.test.ui.po.CreateSpacePage;
 import org.xwiki.test.ui.po.DocumentDoesNotExistPage;
@@ -84,7 +85,10 @@ public class CreatePageTest extends AbstractAdminAuthenticatedTest
      * Tests if a new page can be created from a template.
      */
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason = "See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testCreatePageFromTemplate()
     {
         // Setup the correct environment for the test
@@ -395,7 +399,10 @@ public class CreatePageTest extends AbstractAdminAuthenticatedTest
      * Tests the creation of a page from a save and edit template, tests that the page is indeed saved.
      */
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason = "See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testCreatePageWithSaveAndEditTemplate()
     {
         String space = this.getClass().getSimpleName();

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/DeletePageTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/DeletePageTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.xwiki.test.po.xe.HomePage;
+import org.xwiki.test.ui.browser.IgnoreBrowser;
 import org.xwiki.test.ui.po.ConfirmationPage;
 import org.xwiki.test.ui.po.DeletePageOutcomePage;
 import org.xwiki.test.ui.po.ViewPage;
@@ -114,6 +115,7 @@ public class DeletePageTest extends AbstractAdminAuthenticatedTest
     }
 
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
     public void testDeletePageIsImpossibleWhenNoDeleteRights()
     {
         // Logs out to be guest and not have the right to delete

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/EditInlineTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/EditInlineTest.java
@@ -27,6 +27,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.xwiki.test.po.administration.ProfileUserProfilePage;
 import org.xwiki.test.po.tag.TaggablePage;
+import org.xwiki.test.ui.browser.IgnoreBrowser;
 import org.xwiki.test.ui.po.InlinePage;
 import org.xwiki.test.ui.po.ViewPage;
 import org.xwiki.test.ui.po.editor.ObjectEditPage;
@@ -80,6 +81,7 @@ public class EditInlineTest extends AbstractAdminAuthenticatedTest
 
     /* See XWIKI-2389 */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
     public void testInlineEditPreservesTitle()
     {
         String title = RandomStringUtils.randomAlphanumeric(4);
@@ -105,6 +107,7 @@ public class EditInlineTest extends AbstractAdminAuthenticatedTest
 
     /* See XWIKI-2199 */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
     public void testInlineEditPreservesTags()
     {
         String tag1 = RandomStringUtils.randomAlphanumeric(4);

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/EditObjectsTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/EditObjectsTest.java
@@ -26,6 +26,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.xwiki.test.ui.browser.IgnoreBrowser;
+import org.xwiki.test.ui.browser.IgnoreBrowsers;
 import org.xwiki.test.ui.po.FormElement;
 import org.xwiki.test.ui.po.ViewPage;
 import org.xwiki.test.ui.po.editor.ClassEditPage;
@@ -74,7 +75,10 @@ public class EditObjectsTest extends AbstractAdminAuthenticatedTest
      * Tests that XWIKI-1621 remains fixed.
      */
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testChangeMultiselectProperty()
     {
         // Create a class with a database list property set to return all documents
@@ -277,7 +281,10 @@ public class EditObjectsTest extends AbstractAdminAuthenticatedTest
     }
 
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testObjectAddAndRemove()
     {
         ObjectEditPage oep = ObjectEditPage.gotoPage("Test", "EditObjectsTestObject");

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/EditWYSIWYGTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/EditWYSIWYGTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 import org.openqa.selenium.Keys;
 import org.xwiki.test.po.administration.ProfileUserProfilePage;
 import org.xwiki.test.ui.browser.IgnoreBrowser;
+import org.xwiki.test.ui.browser.IgnoreBrowsers;
 import org.xwiki.test.ui.po.editor.ProfileEditPage;
 import org.xwiki.test.ui.po.editor.WYSIWYGEditPage;
 import org.xwiki.test.ui.po.editor.wysiwyg.EditorElement;
@@ -63,7 +64,10 @@ public class EditWYSIWYGTest extends AbstractAdminAuthenticatedTest
      *      and previewing it without saving the page first makes the XWiki page corrupt.
      **/
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testUploadImageAfterPreview()
     {
         this.editPage.clickPreview().clickBackToEdit();
@@ -78,7 +82,10 @@ public class EditWYSIWYGTest extends AbstractAdminAuthenticatedTest
      * @see XWIKI:7028: Strange behaviour when pressing back and forward on a page that has 2 WYSIWYG editors displayed.
      */
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testBackForwardCache()
     {
         ProfileEditPage profileEditPage = ProfileUserProfilePage.gotoPage("Admin").editProfile();
@@ -96,7 +103,10 @@ public class EditWYSIWYGTest extends AbstractAdminAuthenticatedTest
      * Test that the content of the rich text area is preserved when the user refreshes the page.
      */
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testPreserveUnsavedRichContentAgainstRefresh()
     {
         // Type text and refresh the page.
@@ -117,7 +127,10 @@ public class EditWYSIWYGTest extends AbstractAdminAuthenticatedTest
      * Test that the content of the source text area is preserved when the user refreshes the page.
      */
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testPreserveUnsavedSourceAgainstRefresh()
     {
         EditorElement editor = this.editPage.getContentEditor();
@@ -140,7 +153,10 @@ public class EditWYSIWYGTest extends AbstractAdminAuthenticatedTest
      * Tests that the currently active editor (WYSIWYG or Source) is preserved when the user refreshes the page.
      */
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testPreserveSelectedEditorAgainstRefresh()
     {
         // The WYSIWYG editor should be initially active.

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/KeyboardShortcutsTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/KeyboardShortcutsTest.java
@@ -24,6 +24,7 @@ import junit.framework.Assert;
 import org.junit.Test;
 import org.openqa.selenium.Keys;
 import org.xwiki.test.ui.browser.IgnoreBrowser;
+import org.xwiki.test.ui.browser.IgnoreBrowsers;
 import org.xwiki.test.ui.po.ViewPage;
 
 /**
@@ -37,7 +38,10 @@ public class KeyboardShortcutsTest extends AbstractAdminAuthenticatedTest
     private TestUtils util = new TestUtils();
 
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testKeyboardShortcuts()
     {
         ViewPage vp = util.gotoPage("Sandbox", "WebHome");

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/LoginTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/LoginTest.java
@@ -24,6 +24,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.xwiki.test.po.administration.GlobalRightsAdministrationSectionPage;
 import org.xwiki.test.ui.browser.IgnoreBrowser;
+import org.xwiki.test.ui.browser.IgnoreBrowsers;
 import org.xwiki.test.ui.po.LoginPage;
 import org.xwiki.test.ui.po.ResubmissionPage;
 import org.xwiki.test.ui.po.ViewPage;
@@ -53,7 +54,10 @@ public class LoginTest extends AbstractTest
     }
 
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testLoginLogoutAsAdmin()
     {
         LoginPage loginPage = this.vp.login();
@@ -73,7 +77,10 @@ public class LoginTest extends AbstractTest
     }
 
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testLoginWithInvalidCredentials()
     {
         LoginPage loginPage = this.vp.login();
@@ -82,7 +89,10 @@ public class LoginTest extends AbstractTest
     }
 
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testLoginWithInvalidUsername()
     {
         LoginPage loginPage = this.vp.login();
@@ -127,7 +137,10 @@ public class LoginTest extends AbstractTest
     }
 
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testRedirectPreservesPOSTParameters()
     {
         String test = "Test string " + System.currentTimeMillis();
@@ -159,7 +172,10 @@ public class LoginTest extends AbstractTest
     }
 
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testCorrectUrlIsAccessedAfterLogin()
     {
         // We will choose the Scheduler.WebHome page to make our testing
@@ -174,7 +190,10 @@ public class LoginTest extends AbstractTest
     }
 
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testDataIsPreservedAfterLogin()
     {
         getUtil().gotoPage("Test", "TestData", "save", "content=this+should+not+be+saved");

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/RegisterTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/RegisterTest.java
@@ -29,6 +29,7 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.WebDriverException;
 import org.xwiki.test.po.administration.AdministrationSectionPage;
 import org.xwiki.test.ui.browser.IgnoreBrowser;
+import org.xwiki.test.ui.browser.IgnoreBrowsers;
 import org.xwiki.test.ui.po.AbstractRegistrationPage;
 import org.xwiki.test.ui.po.RegistrationPage;
 
@@ -93,7 +94,10 @@ public class RegisterTest extends AbstractTest
     }
 
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testRegisterJohnSmith()
     {
         Assert.assertTrue(validateAndRegister());
@@ -101,7 +105,10 @@ public class RegisterTest extends AbstractTest
     }
 
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testRegisterExistingUser()
     {
         registrationPage.fillRegisterForm(null, null, "Admin", null, null, null);
@@ -111,7 +118,10 @@ public class RegisterTest extends AbstractTest
     }
 
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testRegisterPasswordTooShort()
     {
         this.registrationPage.fillRegisterForm(null, null, null, "short", "short", null);
@@ -120,7 +130,10 @@ public class RegisterTest extends AbstractTest
     }
 
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testRegisterDifferentPasswords()
     {
         this.registrationPage.fillRegisterForm(null, null, null, null, "DifferentPassword", null);
@@ -129,7 +142,10 @@ public class RegisterTest extends AbstractTest
     }
 
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testRegisterEmptyPassword()
     {
         this.registrationPage.fillRegisterForm(null, null, null, "", "", null);
@@ -138,7 +154,10 @@ public class RegisterTest extends AbstractTest
     }
 
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testRegisterEmptyUserName()
     {
         // A piece of javascript fills in the username with the first and last names so we will empty them.
@@ -148,7 +167,10 @@ public class RegisterTest extends AbstractTest
     }
 
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testRegisterInvalidEmail()
     {
         this.registrationPage.fillRegisterForm(null, null, null, null, null, "not an email address");

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/SectionTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/SectionTest.java
@@ -21,6 +21,7 @@ package org.xwiki.test.ui;
 
 import org.junit.Test;
 import org.xwiki.test.ui.browser.IgnoreBrowser;
+import org.xwiki.test.ui.browser.IgnoreBrowsers;
 import org.xwiki.test.ui.po.ViewPage;
 import org.xwiki.test.ui.po.editor.WYSIWYGEditPage;
 import org.xwiki.test.ui.po.editor.WikiEditPage;
@@ -69,7 +70,10 @@ public class SectionTest extends AbstractAdminAuthenticatedTest
      * See XWIKI-174: Sectional editing.
      */
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testSectionEditInEditorWhenSyntax10()
     {
         ViewPage vp = createTestPages("xwiki/1.0");
@@ -103,7 +107,10 @@ public class SectionTest extends AbstractAdminAuthenticatedTest
      * See XWIKI-2881: Implement Section editing.
      */
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testSectionEditInWikiEditorWhenSyntax2x()
     {
         testSectionEditInWikiEditorWhenSyntax2x("xwiki/2.0");
@@ -144,7 +151,10 @@ public class SectionTest extends AbstractAdminAuthenticatedTest
      * See XWIKI-4033: When saving after section edit entire page is overwritten.
      */
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testSectionSaveDoesNotOverwriteTheWholeContentWhenSyntax10()
     {
         ViewPage vp = createTestPages("xwiki/1.0");
@@ -159,7 +169,10 @@ public class SectionTest extends AbstractAdminAuthenticatedTest
      * See XWIKI-4033: When saving after section edit entire page is overwritten.
      */
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testSectionSaveDoesNotOverwriteTheWholeContentWhenSyntax20()
     {
         ViewPage vp = createTestPages("xwiki/2.0");

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/TemplateTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/TemplateTest.java
@@ -24,6 +24,7 @@ import junit.framework.Assert;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.xwiki.test.ui.browser.IgnoreBrowser;
+import org.xwiki.test.ui.browser.IgnoreBrowsers;
 import org.xwiki.test.ui.po.editor.WikiEditPage;
 
 /**
@@ -41,7 +42,10 @@ public class TemplateTest extends AbstractAdminAuthenticatedTest
      * Test that velocity is rendered
      */
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testHelloVelocity()
     {
         String hello = "Hello Velocity Test Test Test";
@@ -53,7 +57,10 @@ public class TemplateTest extends AbstractAdminAuthenticatedTest
      * Test that an included existing template is displayed correctly
      */
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testCorrectTemplate()
     {
         saveVelocity(includeTemplate("code.vm"), true);
@@ -65,7 +72,10 @@ public class TemplateTest extends AbstractAdminAuthenticatedTest
      * See XWIKI-2580
      */
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testWrongTemplate()
     {
         saveVelocity(includeTemplate("../../"));

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/VersionTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/VersionTest.java
@@ -23,6 +23,7 @@ import junit.framework.Assert;
 
 import org.junit.Test;
 import org.xwiki.test.ui.browser.IgnoreBrowser;
+import org.xwiki.test.ui.browser.IgnoreBrowsers;
 import org.xwiki.test.ui.po.HistoryTab;
 import org.xwiki.test.ui.po.ViewPage;
 import org.xwiki.test.ui.po.editor.WikiEditPage;
@@ -46,7 +47,10 @@ public class VersionTest extends AbstractAdminAuthenticatedTest
     private static final String CONTENT2 = "Second version of Content";
 
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testRollbackToFirstVersion() throws Exception
     {
         getUtil().deletePage(SPACE_NAME, PAGE_NAME);

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/administration/ImportTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/administration/ImportTest.java
@@ -30,6 +30,7 @@ import org.xwiki.test.ui.AbstractAdminAuthenticatedTest;
 import org.xwiki.test.po.administration.AdministrationPage;
 import org.xwiki.test.po.administration.ImportAdministrationSectionPage;
 import org.xwiki.test.ui.browser.IgnoreBrowser;
+import org.xwiki.test.ui.browser.IgnoreBrowsers;
 import org.xwiki.test.ui.po.HistoryTab;
 import org.xwiki.test.ui.po.ViewPage;
 
@@ -87,7 +88,10 @@ public class ImportTest extends AbstractAdminAuthenticatedTest
     }
 
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testImportWithHistory()
     {
         URL fileUrl = this.getClass().getResource("/administration/" + PACKAGE_WITH_HISTORY);
@@ -111,7 +115,10 @@ public class ImportTest extends AbstractAdminAuthenticatedTest
     }
 
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testImportWithNewHistoryVersion()
     {
         URL fileUrl = this.getClass().getResource("/administration/" + PACKAGE_WITHOUT_HISTORY);
@@ -133,7 +140,10 @@ public class ImportTest extends AbstractAdminAuthenticatedTest
     }
 
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testImportAsBackup()
     {
         URL fileUrl = this.getClass().getResource("/administration/" + BACKUP_PACKAGE);
@@ -157,7 +167,10 @@ public class ImportTest extends AbstractAdminAuthenticatedTest
     }
 
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testImportWhenImportAsBackupIsNotSelected()
     {
         URL fileUrl = this.getClass().getResource("/administration/" + BACKUP_PACKAGE);

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/administration/UserProfileTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/administration/UserProfileTest.java
@@ -29,6 +29,7 @@ import org.xwiki.test.ui.AbstractTest;
 import org.xwiki.test.po.administration.PreferencesUserProfilePage;
 import org.xwiki.test.po.administration.ProfileUserProfilePage;
 import org.xwiki.test.ui.browser.IgnoreBrowser;
+import org.xwiki.test.ui.browser.IgnoreBrowsers;
 import org.xwiki.test.ui.po.editor.ChangeAvatarPage;
 import org.xwiki.test.ui.po.editor.ChangePasswordPage;
 import org.xwiki.test.ui.po.editor.PreferencesEditPage;
@@ -94,7 +95,10 @@ public class UserProfileTest extends AbstractTest
 
     /** Functionality check: changing profile information. */
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testEditProfile()
     {
         ProfileEditPage profileEditPage = this.customProfilePage.editProfile();
@@ -125,7 +129,10 @@ public class UserProfileTest extends AbstractTest
 
     /** Functionality check: changing the profile picture. */
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testChangeAvatarImage()
     {
         ChangeAvatarPage changeAvatarImage = this.customProfilePage.changeAvatarImage();

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/annotations/AnnotationsTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/annotations/AnnotationsTest.java
@@ -25,6 +25,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.xwiki.test.ui.AbstractAdminAuthenticatedTest;
 import org.xwiki.test.ui.browser.IgnoreBrowser;
+import org.xwiki.test.ui.browser.IgnoreBrowsers;
 import org.xwiki.test.po.annotations.AnnotatableViewPage;
 
 /**
@@ -68,7 +69,10 @@ public class AnnotationsTest extends AbstractAdminAuthenticatedTest
     }
 
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void AddAndDeleteAnnotations()
     {
         annotatableViewPage.addAnnotation(ANNOTATED_TEXT_1, ANNOTATION_TEXT_1);

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/annotations/AnnotationsTestInOldSyntax.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/annotations/AnnotationsTestInOldSyntax.java
@@ -25,6 +25,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.xwiki.test.ui.AbstractAdminAuthenticatedTest;
+import org.xwiki.test.ui.browser.IgnoreBrowser;
 import org.xwiki.test.po.administration.AdministrationPage;
 import org.xwiki.test.po.administration.AnnotationsPage;
 import org.xwiki.test.po.annotations.AnnotatableViewPage;
@@ -66,6 +67,7 @@ public class AnnotationsTestInOldSyntax extends AbstractAdminAuthenticatedTest
      * are shown This test is against XAANNOTATIONS-17
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
     public void xwikiPageSyntaxAnnotations()
     {
         annotatableViewPage.showAnnotationsPane();

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/appwithinminutes/AddEntryTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/appwithinminutes/AddEntryTest.java
@@ -33,6 +33,7 @@ import org.xwiki.test.po.appwithinminutes.EntryEditPage;
 import org.xwiki.test.po.appwithinminutes.EntryNamePane;
 import org.xwiki.test.ui.AbstractAdminAuthenticatedTest;
 import org.xwiki.test.ui.browser.IgnoreBrowser;
+import org.xwiki.test.ui.browser.IgnoreBrowsers;
 import org.xwiki.test.ui.po.LiveTableElement;
 
 /**
@@ -67,7 +68,10 @@ public class AddEntryTest extends AbstractAdminAuthenticatedTest
      * Tests that entry name is URL encoded.
      */
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testEntryNameWithURLSpecialCharacters()
     {
         EntryNamePane entryNamePane = homePage.clickAddNewEntry();

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/appwithinminutes/ApplicationNameTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/appwithinminutes/ApplicationNameTest.java
@@ -26,6 +26,7 @@ import org.openqa.selenium.Keys;
 import org.xwiki.test.ui.AbstractAdminAuthenticatedTest;
 import org.xwiki.test.po.appwithinminutes.ApplicationCreatePage;
 import org.xwiki.test.ui.browser.IgnoreBrowser;
+import org.xwiki.test.ui.browser.IgnoreBrowsers;
 import org.xwiki.test.ui.po.ViewPage;
 
 /**
@@ -56,7 +57,10 @@ public class ApplicationNameTest extends AbstractAdminAuthenticatedTest
      * Try to create an application with an empty name using the next step button.
      */
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testEmptyAppNameWithNextStepButton()
     {
         ApplicationCreatePage appCreatePage = ApplicationCreatePage.gotoPage();
@@ -91,7 +95,10 @@ public class ApplicationNameTest extends AbstractAdminAuthenticatedTest
      * Try to create an application with an empty name using the Enter key.
      */
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testEmptyAppNameWithEnter()
     {
         ApplicationCreatePage appCreatePage = ApplicationCreatePage.gotoPage();
@@ -127,7 +134,10 @@ public class ApplicationNameTest extends AbstractAdminAuthenticatedTest
      * Try to create an application with a name that can't be used to compute a valid class name.
      */
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testInvalidAppName()
     {
         ApplicationCreatePage appCreatePage = ApplicationCreatePage.gotoPage();
@@ -163,7 +173,10 @@ public class ApplicationNameTest extends AbstractAdminAuthenticatedTest
      * Try to input the name of an existing application.
      */
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testExistingAppName()
     {
         ApplicationCreatePage appCreatePage = ApplicationCreatePage.gotoPage();

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/appwithinminutes/AppsLiveTableTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/appwithinminutes/AppsLiveTableTest.java
@@ -33,6 +33,7 @@ import org.xwiki.test.po.appwithinminutes.ApplicationsLiveTableElement;
 import org.xwiki.test.po.appwithinminutes.ClassFieldEditPane;
 import org.xwiki.test.ui.AbstractTest;
 import org.xwiki.test.ui.browser.IgnoreBrowser;
+import org.xwiki.test.ui.browser.IgnoreBrowsers;
 
 /**
  * Tests the live table that lists the existing applications on the AppWithinMinutes home page.
@@ -60,7 +61,10 @@ public class AppsLiveTableTest extends AbstractTest
      * Creates an application and deletes it using the Actions column from the applications live table.
      */
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testDeleteApplication()
     {
         // Create the application.
@@ -99,7 +103,10 @@ public class AppsLiveTableTest extends AbstractTest
      * Creates an application and edits it using the Actions column from the applications live table.
      */
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testEditApplication()
     {
         // Create the application.
@@ -130,7 +137,10 @@ public class AppsLiveTableTest extends AbstractTest
      * Tests that the actions are displayed only when the current user has the right to perform them.
      */
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testActionRights()
     {
         // Create the application.

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/appwithinminutes/ClassEditorTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/appwithinminutes/ClassEditorTest.java
@@ -30,6 +30,7 @@ import org.xwiki.test.po.appwithinminutes.EntryEditPage;
 import org.xwiki.test.po.appwithinminutes.LongTextClassFieldEditPane;
 import org.xwiki.test.po.xe.ClassSheetPage;
 import org.xwiki.test.ui.browser.IgnoreBrowser;
+import org.xwiki.test.ui.browser.IgnoreBrowsers;
 import org.xwiki.test.ui.po.ViewPage;
 import org.xwiki.test.ui.po.editor.ObjectEditPage;
 
@@ -50,7 +51,10 @@ public class ClassEditorTest extends AbstractClassEditorTest
      * Tests that the hint is displayed only when the canvas is empty.
      */
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testEmptyCanvasHint()
     {
         Assert.assertTrue(editor.getContent().contains(EMPTY_CANVAS_HINT));
@@ -64,7 +68,10 @@ public class ClassEditorTest extends AbstractClassEditorTest
      * Tests that the field display is updated when the configuration panel is closed.
      */
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testApplyConfigurationChanges()
     {
         LongTextClassFieldEditPane longTextField =
@@ -80,7 +87,10 @@ public class ClassEditorTest extends AbstractClassEditorTest
      * Tests that class fields can be deleted and that documents having objects of that class are updated.
      */
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testDeleteField()
     {
         // Add two fields.
@@ -112,7 +122,10 @@ public class ClassEditorTest extends AbstractClassEditorTest
      * Tests that class fields can be reordered.
      */
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testReorderFields()
     {
         // Add two class fields.
@@ -151,7 +164,10 @@ public class ClassEditorTest extends AbstractClassEditorTest
      * Tests that class fields can be renamed.
      */
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testRenameField()
     {
         // Add a class field.
@@ -184,7 +200,10 @@ public class ClassEditorTest extends AbstractClassEditorTest
      * Tests that invalid field names are not allowed.
      */
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testInvalidFieldName()
     {
         String invalidFieldNameErrorMessage = "Property names must follow these naming rules:";
@@ -218,7 +237,10 @@ public class ClassEditorTest extends AbstractClassEditorTest
      * Tests that two class fields can't have the same name.
      */
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testDuplicateFieldName()
     {
         ClassFieldEditPane field = editor.addField("Short Text");
@@ -239,7 +261,10 @@ public class ClassEditorTest extends AbstractClassEditorTest
      * Tests that swapping field names is not allowed.
      */
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testSwapFieldNames()
     {
         ClassFieldEditPane field = editor.addField("Short Text");
@@ -269,7 +294,10 @@ public class ClassEditorTest extends AbstractClassEditorTest
      * Tests the options to update the class sheet and the class template.
      */
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testUpdateSheetAndTemplate()
     {
         // The options panel is not displayed if the class template and sheet don't exists.
@@ -309,7 +337,10 @@ public class ClassEditorTest extends AbstractClassEditorTest
      * Tests the Save & Continue button.
      */
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testSaveAndContinue()
     {
         editor.addField("Date");
@@ -340,7 +371,10 @@ public class ClassEditorTest extends AbstractClassEditorTest
      * Tests that fields names are auto-generated properly.
      */
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testFieldNameAutoGeneration()
     {
         // Add a class field and set its name to an auto-generated field name for a different type.
@@ -367,7 +401,10 @@ public class ClassEditorTest extends AbstractClassEditorTest
      * Test that Save And Continue supports field renames.
      */
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testRenameWithSaveAndContinue()
     {
         // Add a class field.

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/appwithinminutes/DateClassFieldTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/appwithinminutes/DateClassFieldTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 import org.xwiki.test.po.appwithinminutes.DateClassFieldEditPane;
 import org.xwiki.test.po.appwithinminutes.DatePicker;
 import org.xwiki.test.ui.browser.IgnoreBrowser;
+import org.xwiki.test.ui.browser.IgnoreBrowsers;
 
 /**
  * Special class editor tests that address only the Date class field type.
@@ -41,7 +42,10 @@ public class DateClassFieldTest extends AbstractClassEditorTest
      * Tests that the user can select a date using the date picker.
      */
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testDatePicker()
     {
         // First select a date using the picker and assert the value of the date input.
@@ -76,7 +80,10 @@ public class DateClassFieldTest extends AbstractClassEditorTest
      * serialized using the specified date format.
      */
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testDateFormat()
     {
         // Add a date field and change the date format.

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/appwithinminutes/LiveTableEditorTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/appwithinminutes/LiveTableEditorTest.java
@@ -30,6 +30,7 @@ import org.xwiki.test.po.appwithinminutes.ApplicationHomeEditPage;
 import org.xwiki.test.po.appwithinminutes.ApplicationHomePage;
 import org.xwiki.test.ui.AbstractAdminAuthenticatedTest;
 import org.xwiki.test.ui.browser.IgnoreBrowser;
+import org.xwiki.test.ui.browser.IgnoreBrowsers;
 import org.xwiki.test.ui.po.LiveTableElement;
 
 /**
@@ -68,7 +69,10 @@ public class LiveTableEditorTest extends AbstractAdminAuthenticatedTest
      * Adds, removes and reorders live table columns.
      */
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testManageColumns()
     {
         editPage.addLiveTableColumn("First Name");
@@ -87,7 +91,10 @@ public class LiveTableEditorTest extends AbstractAdminAuthenticatedTest
      * Tests that Save & Continue works fine.
      */
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testSaveAndContinue()
     {
         editPage.setDescription("wait for WYSIWYG to load");

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/appwithinminutes/StaticListClassFieldTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/appwithinminutes/StaticListClassFieldTest.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 import org.xwiki.test.po.appwithinminutes.StaticListClassFieldEditPane;
 import org.xwiki.test.po.appwithinminutes.StaticListItemsEditor;
 import org.xwiki.test.ui.browser.IgnoreBrowser;
+import org.xwiki.test.ui.browser.IgnoreBrowsers;
 
 /**
  * Special class editor tests that address only the Static List class field type.
@@ -41,7 +42,10 @@ public class StaticListClassFieldTest extends AbstractClassEditorTest
      * be preserved.
      */
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testDisplayType()
     {
         // Add a new static list field.
@@ -84,7 +88,10 @@ public class StaticListClassFieldTest extends AbstractClassEditorTest
      * Tests that multiple select state is synchronized with the rest of the meta properties.
      */
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testMultipleSelect()
     {
         // Add a new static list field.
@@ -115,7 +122,10 @@ public class StaticListClassFieldTest extends AbstractClassEditorTest
      * Tests the ability to add, edit and remove list items.
      */
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testItemsEditor()
     {
         // Add a new static list field.

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/appwithinminutes/WizardTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/appwithinminutes/WizardTest.java
@@ -35,6 +35,7 @@ import org.xwiki.test.po.appwithinminutes.EntryEditPage;
 import org.xwiki.test.po.appwithinminutes.EntryNamePane;
 import org.xwiki.test.ui.AbstractTest;
 import org.xwiki.test.ui.browser.IgnoreBrowser;
+import org.xwiki.test.ui.browser.IgnoreBrowsers;
 import org.xwiki.test.ui.po.LiveTableElement;
 
 /**
@@ -67,7 +68,10 @@ public class WizardTest extends AbstractTest
      * Tests the application creation process from start to end.
      */
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testCreateApplication()
     {
         // Step 1
@@ -207,7 +211,10 @@ public class WizardTest extends AbstractTest
      * @see XWIKI-7380: Cannot go back from step 2 to step 1
      */
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testGoBackToFirstStep()
     {
         // Step 1

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/blog/BlogPostTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/blog/BlogPostTest.java
@@ -27,6 +27,7 @@ import junit.framework.Assert;
 import org.junit.Test;
 import org.xwiki.test.ui.AbstractAdminAuthenticatedTest;
 import org.xwiki.test.ui.browser.IgnoreBrowser;
+import org.xwiki.test.ui.browser.IgnoreBrowsers;
 import org.xwiki.test.po.blog.BlogHomePage;
 import org.xwiki.test.po.blog.BlogPostInlinePage;
 import org.xwiki.test.po.blog.BlogPostViewPage;
@@ -44,7 +45,10 @@ public class BlogPostTest extends AbstractAdminAuthenticatedTest
      * Tests how a blog post is created and then edited.
      */
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testCreateAndEditBlogPost()
     {
         getUtil().deletePage("Blog", getTestMethodName());

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/invitation/InvitationTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/invitation/InvitationTest.java
@@ -42,6 +42,7 @@ import org.xwiki.test.po.invitation.InvitationGuestActionsPage;
 import org.xwiki.test.po.invitation.InvitationMessageDisplayElement;
 import org.xwiki.test.po.invitation.InvitationSenderPage;
 import org.xwiki.test.ui.browser.IgnoreBrowser;
+import org.xwiki.test.ui.browser.IgnoreBrowsers;
 import org.xwiki.test.ui.po.RegistrationPage;
 import org.xwiki.test.ui.po.TableElement;
 import org.xwiki.test.ui.po.editor.ObjectEditPage;
@@ -235,7 +236,10 @@ public class InvitationTest extends AbstractTest
      * will work and message will say mail was sent.
      */
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testUnpermittedUserCannotSendToMultipleAddresses() throws Exception
     {
         TestUtils.Session admin = getUtil().getSession();
@@ -287,7 +291,10 @@ public class InvitationTest extends AbstractTest
      * 4. After an admin marks the message as not spam, the sender can again send mail.
      */
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testSpamReporting() throws Exception
     {
         TestUtils.Session admin = getUtil().getSession();
@@ -454,7 +461,10 @@ public class InvitationTest extends AbstractTest
      * 4. An invitation once accepted can still be reported as spam.
      */
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testAcceptInvitation() throws Exception
     {
         TestUtils.Session admin = getUtil().getSession();
@@ -511,7 +521,10 @@ public class InvitationTest extends AbstractTest
      * 2. Upon recieving an email invitation the guest can register even without register premission.
      */
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testAcceptInvitationToClosedWiki() throws Exception
     {
         TestUtils.Session admin = getUtil().getSession();

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/panels/NewPagePanelTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/panels/NewPagePanelTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.xwiki.test.ui.AbstractAdminAuthenticatedTest;
 import org.xwiki.test.po.panels.NewPagePanel;
 import org.xwiki.test.ui.browser.IgnoreBrowser;
+import org.xwiki.test.ui.browser.IgnoreBrowsers;
 import org.xwiki.test.ui.po.editor.WYSIWYGEditPage;
 
 /**
@@ -38,7 +39,10 @@ public class NewPagePanelTest extends AbstractAdminAuthenticatedTest
      * Tests if a new page can be created using the create page panel.
      */
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testCreatePageFromPanel()
     {
         NewPagePanel newPagePanel = NewPagePanel.gotoPage();

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/scheduler/SchedulerTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/scheduler/SchedulerTest.java
@@ -30,6 +30,7 @@ import org.xwiki.test.po.scheduler.SchedulerPage;
 import org.xwiki.test.po.scheduler.editor.SchedulerEditPage;
 import org.xwiki.test.ui.AbstractAdminAuthenticatedTest;
 import org.xwiki.test.ui.browser.IgnoreBrowser;
+import org.xwiki.test.ui.browser.IgnoreBrowsers;
 import org.xwiki.test.ui.po.ViewPage;
 
 /**
@@ -58,6 +59,7 @@ public class SchedulerTest extends AbstractAdminAuthenticatedTest
      * Tests that a scheduler job page default edit mode is "inline"
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
     public void testSchedulerJobDefaultEditMode()
     {
         getUtil().gotoPage("Scheduler", "WatchListDailyNotifier");
@@ -65,7 +67,10 @@ public class SchedulerTest extends AbstractAdminAuthenticatedTest
     }
 
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testJobActions()
     {
         // Create Job

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/tag/AddRemoveTagsTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/tag/AddRemoveTagsTest.java
@@ -26,6 +26,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.xwiki.test.ui.AbstractAdminAuthenticatedTest;
 import org.xwiki.test.ui.browser.IgnoreBrowser;
+import org.xwiki.test.ui.browser.IgnoreBrowsers;
 import org.xwiki.test.po.tag.AddTagsPane;
 import org.xwiki.test.po.tag.TaggablePage;
 
@@ -58,6 +59,7 @@ public class AddRemoveTagsTest extends AbstractAdminAuthenticatedTest
      * Adds and removes a tag.
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
     public void testAddRemoveTag()
     {
         String tag = RandomStringUtils.randomAlphanumeric(4);
@@ -74,6 +76,7 @@ public class AddRemoveTagsTest extends AbstractAdminAuthenticatedTest
      * Open the add tag panel, cancel then open again the add tag panel and add a new tag.
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
     public void testCancelAddTag()
     {
         String firstTag = RandomStringUtils.randomAlphanumeric(4);
@@ -95,6 +98,10 @@ public class AddRemoveTagsTest extends AbstractAdminAuthenticatedTest
      * Add many tags and remove one of them.
      */
     @Test
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testAddManyRemoveOneTag()
     {
         String firstTag = RandomStringUtils.randomAlphanumeric(4);
@@ -116,7 +123,10 @@ public class AddRemoveTagsTest extends AbstractAdminAuthenticatedTest
      * Tests that a tag can't be added twice to the same page.
      */
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testAddExistingTag()
     {
         String tag = RandomStringUtils.randomAlphanumeric(4);
@@ -136,6 +146,7 @@ public class AddRemoveTagsTest extends AbstractAdminAuthenticatedTest
      * Add a tag that contains the pipe character, which is used to separate stored tags.
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
     public void testAddTagContainingPipe()
     {
         String tag = RandomStringUtils.randomAlphanumeric(3) + "|" + RandomStringUtils.randomAlphanumeric(3);
@@ -156,6 +167,7 @@ public class AddRemoveTagsTest extends AbstractAdminAuthenticatedTest
      *      spaces to tags when white space is not the separator
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
     public void testStripLeadingAndTrailingSpacesFromTags()
     {
         String firstTag = RandomStringUtils.randomAlphanumeric(4);
@@ -175,6 +187,7 @@ public class AddRemoveTagsTest extends AbstractAdminAuthenticatedTest
      *      equal ignoring case with existing tags
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
     public void testTagCaseIsIgnored()
     {
         String firstTag = "taG1";

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/watchlist/AutoWatchTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/watchlist/AutoWatchTest.java
@@ -24,6 +24,7 @@ import junit.framework.Assert;
 import org.apache.commons.lang.RandomStringUtils;
 import org.junit.Before;
 import org.junit.Test;
+import org.xwiki.test.ui.browser.IgnoreBrowser;
 import org.xwiki.test.ui.AbstractTest;
 import org.xwiki.test.po.administration.ProfileUserProfilePage;
 import org.xwiki.test.po.watchlist.WatchlistUserProfilePage;
@@ -57,6 +58,7 @@ public class AutoWatchTest extends AbstractTest
      * Tests that a scheduler job page default edit mode is "inline".
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
     public void testAutomaticWatchNewPage()
     {
         // create a new page

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/watchlist/WatchThisPageAndWholeSpaceTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/watchlist/WatchThisPageAndWholeSpaceTest.java
@@ -28,6 +28,7 @@ import org.openqa.selenium.By;
 import org.xwiki.test.ui.AbstractAdminAuthenticatedTest;
 import org.xwiki.test.po.administration.ProfileUserProfilePage;
 import org.xwiki.test.ui.browser.IgnoreBrowser;
+import org.xwiki.test.ui.browser.IgnoreBrowsers;
 import org.xwiki.test.ui.po.ViewPage;
 import org.xwiki.test.po.scheduler.SchedulerHomePage;
 import org.xwiki.test.po.watchlist.WatchlistUserProfilePage;
@@ -83,7 +84,10 @@ public class WatchThisPageAndWholeSpaceTest extends AbstractAdminAuthenticatedTe
     }
 
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testWatchThisPageAndWholeSpace() throws Exception
     {
         // Clear the list of watched documents and spaces

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/xe/DocumentIndexAttachmentsTabFilterTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/xe/DocumentIndexAttachmentsTabFilterTest.java
@@ -28,6 +28,7 @@ import org.openqa.selenium.WebElement;
 import org.xwiki.index.test.po.AllDocsPage;
 import org.xwiki.test.ui.AbstractAdminAuthenticatedTest;
 import org.xwiki.test.ui.browser.IgnoreBrowser;
+import org.xwiki.test.ui.browser.IgnoreBrowsers;
 import org.xwiki.test.ui.po.LiveTableElement;
 
 /**
@@ -47,7 +48,10 @@ public class DocumentIndexAttachmentsTabFilterTest extends AbstractAdminAuthenti
     // WARN: calling isReady() and waitUntilReady() from LiveTableElement.java inside this class fails.
     // Used example from JIRA issue
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testAttachmentsPane()
     {
         AllDocsPage docsPage = AllDocsPage.gotoPage();

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/xe/SpacesTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/xe/SpacesTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.xwiki.test.po.xe.HomePage;
 import org.xwiki.test.ui.AbstractAdminAuthenticatedTest;
 import org.xwiki.test.ui.browser.IgnoreBrowser;
+import org.xwiki.test.ui.browser.IgnoreBrowsers;
 import org.xwiki.test.ui.po.editor.WYSIWYGEditPage;
 import org.xwiki.test.ui.po.editor.WikiEditPage;
 
@@ -39,7 +40,10 @@ public class SpacesTest extends AbstractAdminAuthenticatedTest
      * Tests if a new space can be created from the Space dashboard.
      */
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testCreateSpace()
     {
         HomePage homePage = HomePage.gotoPage();
@@ -54,7 +58,10 @@ public class SpacesTest extends AbstractAdminAuthenticatedTest
     }
 
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testLinkToSpaceIndexWhenSpecialCharacterInSpaceName()
     {
         String spaceName = getTestClassName() + "&";


### PR DESCRIPTION
XE-1176: Exclude failing Selenium 2 tests on IE9 from running
