### PR TITLE
Add additional webdav tests for filenames that should be url encoded.

### DIFF
--- a/xwiki-enterprise-test/xwiki-enterprise-test-webdav/src/test/it/org/xwiki/test/webdav/AbstractWebDAVTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-webdav/src/test/it/org/xwiki/test/webdav/AbstractWebDAVTest.java
@@ -49,6 +49,23 @@ public class AbstractWebDAVTest extends TestCase
      * Root webdav view.
      */
     public static final String ROOT = "http://localhost:8080/xwiki/webdav";
+    
+    /** Build a correct escaped URI from the URI constructor */
+    
+    /** URI scheme */
+    public static final String URI_SCHEME = "http";
+
+    /** URI host */
+    public static final String URI_HOST = "localhost";
+    
+    /** URI port */
+    public static final int URI_PORT = 8080;
+    
+    /** URI webdav root */
+    public static final String URI_WEBDAV_ROOT = "/xwiki/webdav";
+    
+    /** location of the spaces view (uri construction) */
+    public static final String PATH_SPACES_VIEW = "/spaces";
 
     /**
      * location of the home view.

--- a/xwiki-enterprise-test/xwiki-enterprise-test-webdav/src/test/it/org/xwiki/test/webdav/DefaultWebDAVTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-webdav/src/test/it/org/xwiki/test/webdav/DefaultWebDAVTest.java
@@ -215,7 +215,7 @@ public class DefaultWebDAVTest extends AbstractWebDAVTest
      */
     public void testMakingAttachment()
     {
-        testMakingAttachmentFile("attachment.txt","normal text file")        
+        testMakingAttachmentFile("attachment.txt","normal text file");
     }
 
     /**
@@ -232,15 +232,45 @@ public class DefaultWebDAVTest extends AbstractWebDAVTest
         testMakingAttachmentFile("%percent.txt","percent");
         testMakingAttachmentFile("plus+plus.txt","plus");
     }
+    
+    /** 
+     * Properly escape the given url path, using RFC 2396.
+     * This will properly convert encode, and quote illegal characters correctly.
+     */
+    protected String getEscapedUrl(String pagePath){
+        String escapedUrl = "";
+        try{
+            java.net.URI uri = new java.net.URI(
+                    URI_SCHEME, //scheme
+                    null, //no user info                    
+                    URI_HOST, //host
+                    URI_PORT, //port
+                    pagePath, //path
+                    null, //no query                    
+                    null); //no #fragment
+            
+            escapedUrl = uri.toASCIIString();
+        }catch(java.net.URISyntaxException ue){
+            fail("Could not escape url: '"+pagePath+"' "+ue.getMessage());
+        }
+        
+        return escapedUrl;
+    }
 
     /**
      * Test making attachment with filename given under /TestSpace/TestPage
      */
     protected void testMakingAttachmentFile(String filename, String testing)
-    {
-        String spaceUrl = SPACES + "/TestSpace";
-        String pageUrl = spaceUrl + "/TestPage";
-        String attachmentUrl = pageUrl + "/"+filename;
+    {                      
+        String spaceUrl = getEscapedUrl(
+                    URI_WEBDAV_ROOT + PATH_SPACES_VIEW + "/TestSpace");
+
+        String pageUrl = getEscapedUrl(
+                URI_WEBDAV_ROOT + PATH_SPACES_VIEW + "/TestSpace/TestPage");        
+
+        String attachmentUrl = getEscapedUrl(
+                URI_WEBDAV_ROOT + PATH_SPACES_VIEW + "/TestSpace/TestPage/" + filename);              
+
         String attachmentContent = "Attachment Content";
         DeleteMethod deleteMethod = new DeleteMethod();
         deleteMethod.setDoAuthentication(true);


### PR DESCRIPTION
Add extra tests for filenames that should be url encoded, hopefully will prevent issues like: XWIKI-7835
