### PR TITLE
Add attachments with filenames requiring url encoding

### DIFF
--- a/xwiki-enterprise-test/xwiki-enterprise-test-rest/src/test/it/org/xwiki/test/rest/AttachmentsResourceTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-rest/src/test/it/org/xwiki/test/rest/AttachmentsResourceTest.java
@@ -92,10 +92,8 @@ public class AttachmentsResourceTest extends AbstractHttpTest
 
         /* Use UriBuilder.buildFromEncoded so we don't double encode the % */
         String attachmentUri =
-            getUriBuilder(AttachmentResource.class).buildFromEncoded(getWiki(), encodedSpaceName, encodedPageName, encodedAttachmentName).toString();               
+            getUriBuilder(AttachmentResource.class).buildFromEncoded(getWiki(), encodedSpaceName, encodedPageName, encodedAttachmentName).toString();
 
-        /** DEBUG URI System.out.println("attachmentUri: "+attachmentUri); */
-        
         GetMethod getMethod = executeGet(attachmentUri);
         Assert.assertEquals(getHttpMethodInfo(getMethod), HttpStatus.SC_NOT_FOUND, getMethod.getStatusCode());
 


### PR DESCRIPTION
to testPUTAttachments().  URL Encode filename before passing to UriBuilder, and use buildFromEncoded() instead of build() to prevent double encoding. Change admin u/pw to constants.
