### PR TITLE
XE-1181: Exclude more failing Selenium 2 tests on IE9 from running

### DIFF
--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/CreatePageTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/CreatePageTest.java
@@ -300,7 +300,10 @@ public class CreatePageTest extends AbstractAdminAuthenticatedTest
      * Tests what happens when creating a page when no template is available in the specific space.
      */
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason = "See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testCreatePageWhenNoTemplateAvailable()
     {
         // prepare the test environment, create a test space and exclude all templates for this space

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/EditWYSIWYGTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/EditWYSIWYGTest.java
@@ -190,7 +190,10 @@ public class EditWYSIWYGTest extends AbstractAdminAuthenticatedTest
      * Test if an undo step reverts only one paste operation from a sequence, and not all of them.
      */
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testUndoRepeatedPaste()
     {
         EditorElement editor = this.editPage.getContentEditor();

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/EditWikiTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/EditWikiTest.java
@@ -25,6 +25,7 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.xwiki.test.ui.browser.IgnoreBrowser;
+import org.xwiki.test.ui.browser.IgnoreBrowsers;
 import org.xwiki.test.ui.po.ViewPage;
 import org.xwiki.test.ui.po.editor.EditPage.Editor;
 import org.xwiki.test.ui.po.editor.WYSIWYGEditPage;
@@ -76,7 +77,10 @@ public class EditWikiTest extends AbstractAdminAuthenticatedTest
      * displayed if the page syntax is xwiki/2.0.
      */
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testSwitchToWysiwygWithAdvancedContent()
     {
         // Place some HTML in the page content.

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/administration/UserProfileTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/administration/UserProfileTest.java
@@ -143,7 +143,10 @@ public class UserProfileTest extends AbstractTest
 
     /** Functionality check: changing the password. */
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testChangePassword()
     {
         // Change the password
@@ -166,7 +169,10 @@ public class UserProfileTest extends AbstractTest
 
     /** Functionality check: changing the user type. */
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testChangeUserProfile()
     {
         PreferencesUserProfilePage preferencesPage = this.customProfilePage.switchToPreferences();
@@ -187,7 +193,10 @@ public class UserProfileTest extends AbstractTest
 
     /** Functionality check: changing the default editor. */
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testChangeDefaultEditor()
     {
         PreferencesUserProfilePage preferencesPage = this.customProfilePage.switchToPreferences();
@@ -238,7 +247,10 @@ public class UserProfileTest extends AbstractTest
     }
 
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testChangePasswordWithTwoDifferentPasswords()
     {
         PreferencesUserProfilePage preferencesPage = this.customProfilePage.switchToPreferences();
@@ -261,7 +273,10 @@ public class UserProfileTest extends AbstractTest
     }
 
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testChangePasswordWithoutEnteringPasswords()
     {
         PreferencesUserProfilePage preferencesPage = this.customProfilePage.switchToPreferences();
@@ -283,7 +298,10 @@ public class UserProfileTest extends AbstractTest
     }
 
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testChangePasswordOfAnotherUserWithTwoDifferentPasswords()
     {
         // Login as Admin and change the password of another user

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/blog/BlogCategoriesTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/blog/BlogCategoriesTest.java
@@ -25,6 +25,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.xwiki.test.ui.AbstractAdminAuthenticatedTest;
 import org.xwiki.test.ui.browser.IgnoreBrowser;
+import org.xwiki.test.ui.browser.IgnoreBrowsers;
 import org.xwiki.test.po.blog.ManageCategoriesPage;
 
 /**
@@ -54,7 +55,10 @@ public class BlogCategoriesTest extends AbstractAdminAuthenticatedTest
     }
 
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testCategoryAddRenameRemove()
     {
         categoryAdd(CATEGORY);

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/invitation/InvitationTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/invitation/InvitationTest.java
@@ -390,7 +390,10 @@ public class InvitationTest extends AbstractTest
      * 5. A guest cannot accept a message which has already been declined.
      */
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testDeclineInvitation() throws Exception
     {
         TestUtils.Session admin = getUtil().getSession();
@@ -596,7 +599,10 @@ public class InvitationTest extends AbstractTest
      * 4. A canceled invitation can still be reported as spam.
      */
     @Test
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146")
+    @IgnoreBrowsers({
+    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See http://jira.xwiki.org/browse/XE-1146"),
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
+    })
     public void testCancelInvitation() throws Exception
     {
         TestUtils.Session admin = getUtil().getSession();
@@ -659,6 +665,7 @@ public class InvitationTest extends AbstractTest
      * 1. A user cannot send to the same address multiple (8000) times which would be very annoying for the recipient.
      */
     @Test
+    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See http://jira.xwiki.org/browse/XE-1177")
     public void testSendManyToOneAddress() throws Exception
     {
         TestUtils.Session admin = getUtil().getSession();


### PR DESCRIPTION
XE-1181: Exclude more failing Selenium 2 tests on IE9 from running due to update to an newer Selenium 2 version
