### PR TITLE
XWIKI-7907

### DIFF
--- a/xwiki-enterprise-ui/src/main/resources/Main/Activity.xml
+++ b/xwiki-enterprise-ui/src/main/resources/Main/Activity.xml
@@ -1443,7 +1443,7 @@ $xwiki.ssx.use('Main.Activity')##
             #set ($pageTitle = $pageName)
           #end
           &lt;a href="$xwiki.getURL(${pageFullName})" class="typePage type"&gt;
-            $!{escapetool.xml($pageTitle)}
+            $pageTitle
           &lt;/a&gt;
         #end
       #else


### PR DESCRIPTION
Multiple spaces inside page title are displayed as '&nbsp;' in Activity Stream
