### PR TITLE
XWIKI-5676: Implement new search engine using Apache Solr

### DIFF
--- a/xwiki-enterprise-distribution/xwiki-enterprise-ui-all/pom.xml
+++ b/xwiki-enterprise-distribution/xwiki-enterprise-ui-all/pom.xml
@@ -21,6 +21,7 @@
       org.xwiki.platform:xwiki-platform-watchlist-ui,
       org.xwiki.platform:xwiki-platform-statistics-ui,
       org.xwiki.platform:xwiki-platform-search-ui,
+      org.xwiki.platform:xwiki-platform-search-solr-ui,
       org.xwiki.platform:xwiki-platform-blog-ui,
       org.xwiki.platform:xwiki-platform-office-ui,
       org.xwiki.platform:xwiki-platform-webdav-ui,

--- a/xwiki-enterprise-ui/pom.xml
+++ b/xwiki-enterprise-ui/pom.xml
@@ -64,6 +64,12 @@
     </dependency>
     <dependency>
       <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-search-solr-ui</artifactId>
+      <version>${platform.version}</version>
+      <type>xar</type>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
       <artifactId>xwiki-platform-blog-ui</artifactId>
       <version>${platform.version}</version>
       <type>xar</type>

--- a/xwiki-enterprise-web/pom.xml
+++ b/xwiki-enterprise-web/pom.xml
@@ -575,6 +575,18 @@ If you wish to have the default wiki pages, which contain both content pages and
       <version>${platform.version}</version>
       <scope>runtime</scope>
     </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-search-solr</artifactId>
+      <version>${platform.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-query-solr</artifactId>
+      <version>${platform.version}</version>
+      <scope>runtime</scope>
+    </dependency>
     <!-- JODA Time -->
     <dependency>
       <groupId>org.xwiki.platform</groupId>


### PR DESCRIPTION
- Bundled the Solr search back-end to XWiki Enterprise by default. Lucene is still the default search.
