### PR TITLE
XE-1325: Integrate the Workspaces feature by default in the default XE distribution.

### DIFF
--- a/xwiki-enterprise-ui/xwiki-enterprise-ui-mainwiki/pom.xml
+++ b/xwiki-enterprise-ui/xwiki-enterprise-ui-mainwiki/pom.xml
@@ -44,7 +44,7 @@
   <dependencies>
     <dependency>
       <groupId>org.xwiki.enterprise</groupId>
-      <artifactId>xwiki-enterprise-common-ui</artifactId>
+      <artifactId>xwiki-enterprise-ui-common</artifactId>
       <version>${platform.version}</version>
       <type>xar</type>
     </dependency>


### PR DESCRIPTION
- Fix a bad archetype name in the dependencies of xwiki-enterprise-ui-mainwiki.
