### PR TITLE
XWIKI-9457: Confusing information in Installed Extensions after migrating from 4.5.4 to 5.2M2.

### DIFF
--- a/xwiki-enterprise-distribution/xwiki-enterprise-ui-mainwiki-all/pom.xml
+++ b/xwiki-enterprise-distribution/xwiki-enterprise-ui-mainwiki-all/pom.xml
@@ -83,7 +83,8 @@
       com.xpn.xwiki.products:xwiki-enterprise-manager-wiki-administrator,
       org.xwiki.manager:xwiki-enterprise-manager-wiki-administrator,
       org.xwiki.manager:xwiki-manager-wiki-administrator,
-      org.xwiki.manager:xwiki-manager-ui
+      org.xwiki.manager:xwiki-manager-ui,
+      org.xwiki.enterprise:xwiki-enterprise-ui-all
     </xwiki.extension.features>
   </properties>
   <dependencies>

--- a/xwiki-enterprise-distribution/xwiki-enterprise-ui-wiki-all/pom.xml
+++ b/xwiki-enterprise-distribution/xwiki-enterprise-ui-wiki-all/pom.xml
@@ -70,7 +70,8 @@
       org.xwiki.platform:xwiki-platform-messagestream-ui,
       org.xwiki.platform:xwiki-platform-sandbox,
       org.xwiki.platform:xwiki-platform-wysiwyg-ui,
-      org.xwiki.platform:xwiki-platform-workspace-template-features
+      org.xwiki.platform:xwiki-platform-workspace-template-features,
+      org.xwiki.enterprise:xwiki-enterprise-ui-all
     </xwiki.extension.features>
   </properties>
   <dependencies>


### PR DESCRIPTION
- Fix pom.xml for xwiki-enterprise-ui-mainwiki-all & xwiki-enterprise-ui-wiki-all.
