### PR TITLE
XWIKI-9456: After the creation of a new (sub)wiki, the Distribution Wizard should not appear.

### DIFF
--- a/xwiki-enterprise-migrator/src/main/java/org/xwiki/enterprise/migrator/internal/Migrator.java
+++ b/xwiki-enterprise-migrator/src/main/java/org/xwiki/enterprise/migrator/internal/Migrator.java
@@ -48,16 +48,16 @@ public class Migrator extends DistributionScriptService
 
         // If there is an object, then it's a "workspace"
         if (wikiDocument.getXObject(workspaceClassRef) != null) {
-            return this.distributionManager.getWikiUIExtensionId();
+            CoreExtension distributionExtension = this.coreExtensionRepository.getEnvironmentExtension();
+            // Get the maven model
+            Model mavenModel = (Model) distributionExtension.getProperty(MavenCoreExtension.PKEY_MAVEN_MODEL);
+            // Get the UI Id
+            String wikiUIId = mavenModel.getProperties().getProperty("xwiki.extension.distribution.workspaceui");
+
+            return new ExtensionId(wikiUIId, distributionExtension.getId().getVersion());
         }
 
         // Other case, it is a "normal" subwiki
-        CoreExtension distributionExtension = this.coreExtensionRepository.getEnvironmentExtension();
-        // Get the maven model
-        Model mavenModel = (Model) distributionExtension.getProperty(MavenCoreExtension.PKEY_MAVEN_MODEL);
-        // Get the UI Id
-        String wikiUIId = mavenModel.getProperties().getProperty("xwiki.extension.distribution.oldwikiui");
-
-        return new ExtensionId(wikiUIId, distributionExtension.getId().getVersion());
+        return this.distributionManager.getWikiUIExtensionId();
     }
 }

--- a/xwiki-enterprise-web/pom.xml
+++ b/xwiki-enterprise-web/pom.xml
@@ -42,8 +42,8 @@ If you wish to have the default wiki pages, which contain both content pages and
 
     <!-- The default UI associated to this WAR -->
     <xwiki.extension.distribution.ui>org.xwiki.enterprise:xwiki-enterprise-ui-mainwiki</xwiki.extension.distribution.ui>
-    <xwiki.extension.distribution.wikiui>org.xwiki.enterprise:xwiki-enterprise-ui-wiki</xwiki.extension.distribution.wikiui>
-    <xwiki.extension.distribution.oldwikiui>org.xwiki.enterprise:xwiki-enterprise-ui-common</xwiki.extension.distribution.oldwikiui>
+    <xwiki.extension.distribution.wikiui>org.xwiki.enterprise:xwiki-enterprise-ui-common</xwiki.extension.distribution.wikiui>
+    <xwiki.extension.distribution.workspaceui>org.xwiki.enterprise:xwiki-enterprise-ui-wiki</xwiki.extension.distribution.workspaceui>
 
     <!-- Old names of this module used for retro compatibility when resolving dependencies of old extensions -->
     <xwiki.extension.features>


### PR DESCRIPTION
- Rename xwiki.extension.distribution.oldwikiui to xwiki.extension.distribution.wikiui
- Inverse xwiki.extension.distribution.wikiui to xwiki.extension.distribution.workspaceui
- Take this change into account in the migrator.
