### PR TITLE
XWIKI-9480: "Upgrade all wikis" option does not work.

### DIFF
--- a/xwiki-enterprise-migrator/src/main/java/org/xwiki/enterprise/migrator/internal/Migrator.java
+++ b/xwiki-enterprise-migrator/src/main/java/org/xwiki/enterprise/migrator/internal/Migrator.java
@@ -34,6 +34,10 @@ public class Migrator extends DistributionScriptService
     @Inject
     private DocumentReferenceResolver documentReferenceResolver;
 
+    /** Logging tool. */
+    @Inject
+    private static Logger logger;
+
     @Override
     public ExtensionId getUIExtensionId(String wiki)
     {
@@ -68,7 +72,7 @@ public class Migrator extends DistributionScriptService
             }
 
         } catch (XWikiException e) {
-            Logger.error("Failed to get wiki descriptor for wiki [{}]", wiki, e);
+            logger.error("Failed to get wiki descriptor for wiki [{}]", wiki, e);
         }
 
         // Other case, it is a "normal" subwiki


### PR DESCRIPTION
- Override getUIExtensionId(wiki) instead of getUIExtensionId()
- Please wait until https://github.com/xwiki/xwiki-platform/tree/feature-upgradeall is merge to master.
