### PR TITLE
XWIKI-9737: The user XWiki.Admin is still created in subwikis.

### DIFF
--- a/xwiki-enterprise-distribution/xwiki-enterprise-ui-mainwiki-all/pom.xml
+++ b/xwiki-enterprise-distribution/xwiki-enterprise-ui-mainwiki-all/pom.xml
@@ -39,6 +39,7 @@
       org.xwiki.enterprise:xwiki-enterprise-ui,
       org.xwiki.enterprise:xwiki-enterprise-ui-mainwiki,
       org.xwiki.enterprise:xwiki-enterprise-ui-common,
+      org.xwiki.enterprise:xwiki-enterprise-ui-admin-user,
       org.xwiki.platform:xwiki-platform-livetable-ui,
       org.xwiki.platform:xwiki-platform-index-ui,
       org.xwiki.platform:xwiki-platform-panels-ui,


### PR DESCRIPTION
- Add xwiki-enterprise-ui-admin-user as an embedded extension of xwiki-enterprise-ui-mainwiki-all.
