### PR TITLE
XWIKI-9738: Finalize migration from workspaces to the new wiki API.

### DIFF
--- a/xwiki-enterprise-web/pom.xml
+++ b/xwiki-enterprise-web/pom.xml
@@ -782,6 +782,12 @@ If you wish to have the default wiki pages, which contain both content pages and
       <version>${platform.version}</version>
       <scope>runtime</scope>
     </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-wiki-workspaces-migrator</artifactId>
+      <version>${platform.version}</version>
+      <scope>runtime</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>


### PR DESCRIPTION
- Add xwiki-platform-wiki-workspaces-migrator as a dependency.

Depends on https://github.com/xwiki/xwiki-platform/pull/233.
