### PR TITLE
XWIKI-11416: Move the "Pretty Name" and Description sections from the Main Wiki to their respective subwiki Administration page

### DIFF
--- a/xwiki-enterprise-ui/xwiki-enterprise-ui-common/pom.xml
+++ b/xwiki-enterprise-ui/xwiki-enterprise-ui-common/pom.xml
@@ -254,6 +254,12 @@
       <version>${platform.version}</version>
       <type>xar</type>
     </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-wiki-ui-common</artifactId>
+      <version>${platform.version}</version>
+      <type>xar</type>
+    </dependency>
     <!-- JAR dependencies -->
     <!-- With strict versions so that XE XAR extension is marked as invalid when they change (upgrading the WAR) -->
     <dependency>


### PR DESCRIPTION
- Added the new common UI elements of the wiki module into XE's common UI, to be used on both the main wiki and subwikis

See xwiki/xwiki-platform#366
