### PR TITLE
XWIKI-11922: New App from AWM should have Main.WebHome as parent page

### DIFF
--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/appwithinminutes/ApplicationNameTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/appwithinminutes/ApplicationNameTest.java
@@ -255,8 +255,7 @@ public class ApplicationNameTest extends AbstractTest
         Assert.assertEquals(dataSpace, homeEditPage.getMetaDataValue("space"));
 
         // Go to the App Within Minutes home page.
-        homeEditPage.clickBreadcrumbLink(AppWithinMinutesHomePage.TITLE);
-        AppWithinMinutesHomePage appWithinMinutesHomePage = new AppWithinMinutesHomePage();
+        AppWithinMinutesHomePage appWithinMinutesHomePage = AppWithinMinutesHomePage.gotoPage();
 
         // Assert that the created application is listed in the live table.
         ApplicationsLiveTableElement appsLiveTable = appWithinMinutesHomePage.getAppsLiveTable();

--- a/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/appwithinminutes/AppsLiveTableTest.java
+++ b/xwiki-enterprise-test/xwiki-enterprise-test-ui/src/test/it/org/xwiki/test/ui/appwithinminutes/AppsLiveTableTest.java
@@ -186,8 +186,7 @@ public class AppsLiveTableTest extends AbstractTest
         ApplicationClassEditPage classEditPage = appCreatePage.clickNextStep();
         classEditPage.addField("Short Text");
         // Wait for the application home edit page to load before clicking finish to be sure the page layout is stable.
-        classEditPage.clickNextStep().waitUntilPageIsLoaded().clickFinish()
-            .clickBreadcrumbLink(AppWithinMinutesHomePage.TITLE);
-        homePage = new AppWithinMinutesHomePage();
+        classEditPage.clickNextStep().waitUntilPageIsLoaded().clickFinish();
+        homePage = AppWithinMinutesHomePage.gotoPage();
     }
 }


### PR DESCRIPTION
* Fixed 2 functional tests that were failing due to deleting the public static final variable TITLE